### PR TITLE
fix for missing data in parsing hrf

### DIFF
--- a/src/main/java/core/model/misc/Verein.java
+++ b/src/main/java/core/model/misc/Verein.java
@@ -73,8 +73,8 @@ public final class Verein {
         m_iFans = DF.parse(properties.getProperty("fanclub", "0")).intValue();
         m_iUngeschlagen = DF.parse(properties.getProperty("undefeated", "0")).intValue();
         m_iSiege = DF.parse(properties.getProperty("victories", "0")).intValue();
-        m_iFinancialDirectorLevels = DF.parse(properties.getProperty("financialDirectorLevels", "0")).intValue();
-        m_iFormCoachLevels = DF.parse(properties.getProperty("formCoachLevels", "0")).intValue();
+        m_iFinancialDirectorLevels = DF.parse(properties.getProperty("financialdirectorlevels", "0")).intValue();
+        m_iFormCoachLevels = DF.parse(properties.getProperty("formcoachlevels", "0")).intValue();
         m_iTacticalAssistantLevels = DF.parse(properties.getProperty("tacticalassistantlevels", "0")).intValue();
     }
 


### PR DESCRIPTION
since properties are saved in lower case they should be searched for in lower case.
now levels for form coach and financial director in the misc tab(not to mention database) are correct.
staff list was ok but levels below were invalid.