### PR TITLE
set line/word wrap to release channel to avoid overflow

### DIFF
--- a/src/main/java/core/option/ReleaseChannelPanel.java
+++ b/src/main/java/core/option/ReleaseChannelPanel.java
@@ -3,6 +3,7 @@ package core.option;
 import core.gui.comp.panel.ImagePanel;
 
 import java.awt.GridLayout;
+import java.awt.Dimension;
 import java.awt.Font;
 
 import javax.swing.*;
@@ -68,6 +69,8 @@ public final class ReleaseChannelPanel extends ImagePanel
         jbg_buttonGroup.add(jrb_Dev);
 
         jl_Description = new JTextArea("", 5, 1);
+        jl_Description.setLineWrap(true);
+        jl_Description.setWrapStyleWord(true);
         jl_Description.setEditable(false);
 
 

--- a/src/main/resources/sprache/English.properties
+++ b/src/main/resources/sprache/English.properties
@@ -788,8 +788,8 @@ tt_Optionen_TabManagement=Select if tabs should be always displayed for the func
 options.tabtitle.release_channels=Release Channels
 options.release_channels_pleaseSelect=Please select the desired release channel
 options.release_channels_STABLE_desc=This channel delivers the latest stable release of HO.\nYou can expect reliability and good performance.
-options.release_channels_BETA_desc=If you are interested in using new features with limited risk, beta channel is for you.\nBeta channel releases normally contain all the features that will be part of the next \nrelease. They are still expected to have some bugs and performance issues.\nIt is also the recommended channel for member of the translation team.
-options.release_channels_DEV_desc=DEV channel is meant in priority for HO core development team.\nHowever, you can select this if you want to get the latest and greatest features,\nbut do not expect a bug-free experience !
+options.release_channels_BETA_desc=If you are interested in using new features with limited risk, beta channel is for you.\nBeta channel releases normally contain all the features that will be part of the next release. They are still expected to have some bugs and performance issues.\nIt is also the recommended channel for member of the translation team.
+options.release_channels_DEV_desc=DEV channel is meant in priority for HO core development team.\nHowever, you can select this if you want to get the latest and greatest features, but do not expect a bug-free experience !
 
 #V1.28
 #Training


### PR DESCRIPTION
Changes proposed in this pull request:

Sets set line/word wrap to release channel text field in options to avoid overflow.   
Also removes awkward newlines.

Graphically changes this:
![przechwycenie obrazu ekranu_2019-01-11_15-37-45](https://user-images.githubusercontent.com/2612128/51040891-e7490980-15b8-11e9-88c3-a20cf11b6946.png)

To that:
![przechwycenie obrazu ekranu_2019-01-11_15-34-32](https://user-images.githubusercontent.com/2612128/51040924-fcbe3380-15b8-11e9-9459-44e2afc41464.png)

Changelog and release_notes:

 - [ ] have been updated
 - [X] do not require update