### PR TITLE
increment database version

### DIFF
--- a/src/main/java/core/db/DBManager.java
+++ b/src/main/java/core/db/DBManager.java
@@ -60,7 +60,7 @@ public class DBManager {
 	// Datum der TSI Umstellung. Alle Marktwerte der Spieler müssen vor dem
 	// Datum durch 1000 geteilt werden (ohne Sprachfaktor)
 	/** database version */
-	private static final int DBVersion = 22;
+	private static final int DBVersion = 23;
 
 	/** 2004-06-14 11:00:00.0 */
 	public static Timestamp TSIDATE = new Timestamp(1087203600000L);


### PR DESCRIPTION
1. changes proposed in this pull request:
 
I should have done it when I introduced `updateDBv23` while working on `transfer history panel`.   
May have partly caused (and hence fix) #72. Additionally fixes a bug that would surface when someone would try to use `transfer history panel` after updating from `stable 1.435` to `stable 1.436`. Database wouldn't have updated and there would be some errors (NullPointerException or sth).

2. changelog and release_notes

 - [ ] have been updated
 - [X] do not require update