### PR TITLE
Issue-182: Not correct building if it is launched from a branch

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -513,19 +513,20 @@ task ZipDistribution(type: Zip) {
 
 task AddResourcesAndZipMacApp {
     dependsOn 'init', 'createApp'
-    def macAppDir = "${buildDir}\\macApp\\HO.app\\Contents\\Java"
     doLast {
+	    def baseMacAppDir = "${buildDir}\\macApp\\${project.macAppBundle.appName}.app"
+	    def macAppDir = "${baseMacAppDir}\\Contents\\Java"
         println("adding resources folder")
         copy {
             from "${projectDir}\\src\\main\\resources\\changelog.html"
-            into "${buildDir}\\macApp\\HO.app"
+            into "${baseMacAppDir}"
         }
         delete "${macAppDir}\\hamcrest-core-1.3.jar"
         delete "${macAppDir}\\junit-4.12.jar"
 
         println("zipping MacApp distribution")
         task(ZipMacAppDistribution, type: Tar) {
-            archiveName = "HO_${project.version}_macOS.zip"
+            archiveName = "${project.macAppBundle.appName}_${project.version}_macOS.zip"
             destinationDir = file("${project.ext.target_dir}")
             from ("${buildDir}\\macApp") {exclude("**\\JavaAppLauncher")}
             from ("${buildDir}\\macApp") {


### PR DESCRIPTION
1. changes proposed in this pull request:
 
   - fixes issue #182 : Not correct building if it is launched from a branch
 
2. changelog and release_notes: do not require update

3. @akasolace I had to move the `def` into `doLast` in order to be able to use parameters from the `macAppBundle` plugin. I hope this is OK (as told, I'm new with Gradle)
I would ask you to check if a standard (full) build works, before accepting the pull request.
I only checked it on Mac (task `makeosX`) and it works fine (i.e. a single `.app` is created that crashes exatly as before the change, that is what is reported in #166).
