### PR TITLE
issue-198 Can't build OsX .app if Java 11 is the default version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -165,7 +165,7 @@ distributions {
 macAppBundle {
     mainClassName = "HOLauncher"
     icon = "${project.ext.osx_app_dir_sourcedir}\\HO.icns"
-    bundleJRE = true
+    bundleJRE = false // true #issue-198
     javaProperties.put("apple.laf.useScreenMenuBar", "true")
     javaProperties.put("apple.awt.showGrowBox", "true")
     backgroundImage = "${project.ext.osx_app_dir_sourcedir}\\Back.png"


### PR DESCRIPTION
1. changes proposed in this pull request:
    - fixes issue #198 
