### PR TITLE
File loader

### DIFF
--- a/src/main/java/core/file/FileLoader.java
+++ b/src/main/java/core/file/FileLoader.java
@@ -52,8 +52,6 @@ public class FileLoader {
 		if (fileStatusesCache.get(fileName)==FileLoadingStatus.NOT_FOUND) return null;
 		boolean fileUnknown = fileStatusesCache.get(fileName)==null;
 		
-		HOLogger.instance().setLogLevel(0);
-		
 		if (fileUnknown || fileStatusesCache.get(fileName)==FileLoadingStatus.OUTISDE_JAR) {
 			File returnFile = new File(fileName);
 			try {

--- a/src/main/java/core/file/FileLoader.java
+++ b/src/main/java/core/file/FileLoader.java
@@ -36,7 +36,7 @@ public class FileLoader {
 	 * Static method to be used in order to get an instance of the FileLoader
 	 * @return
 	 */
-	public static FileLoader getInstance() {
+	public static FileLoader instance() {
 		if (_instance==null) {
 			_instance = new FileLoader();
 		}
@@ -51,6 +51,8 @@ public class FileLoader {
 	public InputStream getFileInputStream(String fileName) {
 		if (fileStatusesCache.get(fileName)==FileLoadingStatus.NOT_FOUND) return null;
 		boolean fileUnknown = fileStatusesCache.get(fileName)==null;
+		
+		HOLogger.instance().setLogLevel(0);
 		
 		if (fileUnknown || fileStatusesCache.get(fileName)==FileLoadingStatus.OUTISDE_JAR) {
 			File returnFile = new File(fileName);

--- a/src/main/java/core/file/FileLoader.java
+++ b/src/main/java/core/file/FileLoader.java
@@ -1,0 +1,80 @@
+package core.file;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.InputStream;
+import java.util.List;
+
+import core.util.HOLogger;
+
+/**
+ * @author cira
+ * 
+ * This class should be used to load any external file.
+ * Other classes using this utility won't need to know if the requested is located inside the
+ * HO.jar file, or at the same level of HO.jar in the directory tree.  
+ */
+
+public class FileLoader {
+
+	private static FileLoader _instance = null;
+	boolean loadFromJar = false;
+	
+	private FileLoader() {
+		//URL testUrl = this.getClass().getClassLoader().getResource("prediction/defaults.xml");
+		//if (testUrl!=null) {
+		File testFile = new File("prediction/defaults.xml");
+		if (testFile.exists()) {
+			HOLogger.instance().error(getClass(), "Files will be searched outside the HO.jar");
+        } else {
+        	loadFromJar = true;
+        	HOLogger.instance().error(getClass(), "Files will be searched into the HO.jar");
+        }
+	}
+	
+	/**
+	 * Static method to be used in order to get an instance of the FileLoader
+	 * @return
+	 */
+	public static FileLoader getInstance() {
+		if (_instance==null) {
+			_instance = new FileLoader();
+		}
+		return _instance;
+	}
+	
+	/**
+	 * Provides access to the InputStream of a requested file 
+	 * @param fileName The name of the file to be returned
+	 * @return the InputStream related to the fileName or <em>null</em> if the file doesn't exist
+	 */
+	public InputStream getFileInputStream(String fileName) {
+		if (!loadFromJar) {
+			File returnFile = new File(fileName);
+			try {
+				return new FileInputStream(returnFile);
+			} catch (FileNotFoundException e) {
+				return null;
+			}
+		} else {
+			return this.getClass().getClassLoader().getResourceAsStream(fileName);
+		}
+	}
+	
+	/**
+	 * Provides access to the InputStream of the first requested file found in the list.
+	 * This can be useful in order to provide one (or more) alternative file(s) to be searched. 
+	 * @param fileNames Ordered list of file names to be returned. 
+	 * @return the InputStream related to the fileName or <em>null</em> if the file doesn't exist
+	 */
+	public InputStream getFileInputStream(List<String> fileNames) {
+		InputStream returnValue = null;
+		for (String fileName : fileNames) {
+			returnValue = this.getFileInputStream(fileName);
+			if (returnValue!=null) break;
+		}
+		return returnValue;
+	}
+	
+}

--- a/src/main/java/core/file/FileLoader.java
+++ b/src/main/java/core/file/FileLoader.java
@@ -22,14 +22,12 @@ public class FileLoader {
 	boolean loadFromJar = false;
 	
 	private FileLoader() {
-		//URL testUrl = this.getClass().getClassLoader().getResource("prediction/defaults.xml");
-		//if (testUrl!=null) {
 		File testFile = new File("prediction/defaults.xml");
 		if (testFile.exists()) {
-			HOLogger.instance().error(getClass(), "Files will be searched outside the HO.jar");
+			HOLogger.instance().info(getClass(), "Files will be searched outside the HO.jar");
         } else {
         	loadFromJar = true;
-        	HOLogger.instance().error(getClass(), "Files will be searched into the HO.jar");
+        	HOLogger.instance().info(getClass(), "Files will be searched into the HO.jar");
         }
 	}
 	
@@ -68,7 +66,7 @@ public class FileLoader {
 	 * @param fileNames Ordered list of file names to be returned. 
 	 * @return the InputStream related to the fileName or <em>null</em> if the file doesn't exist
 	 */
-	public InputStream getFileInputStream(List<String> fileNames) {
+	public InputStream getFileInputStream(String[] fileNames) {
 		InputStream returnValue = null;
 		for (String fileName : fileNames) {
 			returnValue = this.getFileInputStream(fileName);

--- a/src/main/java/core/model/FormulaFactors.java
+++ b/src/main/java/core/model/FormulaFactors.java
@@ -178,7 +178,7 @@ public class FormulaFactors {
      */
     public void readFromXML(String defaults) {
 
-    	InputStream predictionIS = FileLoader.getInstance().getFileInputStream(new String[]{defaults, "prediction/defaults.xml"});
+    	InputStream predictionIS = FileLoader.instance().getFileInputStream(new String[]{defaults, "prediction/defaults.xml"});
     	
     	if (predictionIS!=null) {
     		Document doc = XMLManager.parseFile(predictionIS);

--- a/src/main/java/core/model/FormulaFactors.java
+++ b/src/main/java/core/model/FormulaFactors.java
@@ -1,10 +1,13 @@
 package core.model;
 
+import core.file.FileLoader;
 import core.file.xml.XMLManager;
 import core.model.player.IMatchRoleID;
 import core.util.HOLogger;
 import java.io.File;
 import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Date;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
@@ -176,33 +179,11 @@ public class FormulaFactors {
      * @param defaults the filename of the xml config
      */
     public void readFromXML(String defaults) {
-        Document doc;
 
-        try {
-            File formulaFactorsFile = new File(defaults);
-            if (! formulaFactorsFile.exists()) {
-                try {
-                    formulaFactorsFile = new File(getClass().getClassLoader().getResource("prediction/defaults.xml").getFile());
-                } catch (Exception e) {
-            		HOLogger.instance().error(getClass(),
-            				"Error while loading prediction/defaults.xml (another attempt will follow via classloader): " + e);
-                }
-            }
-
-            // this manages #166
-            if (formulaFactorsFile.exists()) {
-            	doc = XMLManager.parseFile(formulaFactorsFile.getAbsolutePath());
-            } else {
-            	InputStream formulaFactorsIs = this.getClass().getClassLoader().getResourceAsStream(defaults);
-        		if (formulaFactorsIs==null) {
-        			formulaFactorsIs = this.getClass().getClassLoader().getResourceAsStream("prediction/defaults.xml");
-            	}
-        		if (formulaFactorsIs==null) {
-        			HOLogger.instance().error(getClass(), "Error while loading prediction/defaults.xml from HO.jar via classloader: " + this.getClass().getClassLoader().toString());
-        		}
-            	doc = XMLManager.parseFile(formulaFactorsIs);
-            }
-
+    	InputStream predictionIS = FileLoader.getInstance().getFileInputStream(new String[]{defaults, "prediction/defaults.xml"});
+    	
+    	if (predictionIS!=null) {
+    		Document doc = XMLManager.parseFile(predictionIS);
             //Reading xml ==========================================
             final Element root = doc.getDocumentElement();
 
@@ -231,11 +212,9 @@ public class FormulaFactors {
             catch (Exception e) {
                 HOLogger.instance().log(getClass(), "Error when parsing formula factors XML: " + e);
             }
-
-        }
-        catch (Exception e) {
-            HOLogger.instance().error(getClass(), "Error while loading prediction/defaults.xml");
-        }
+    	} else {
+    		HOLogger.instance().error(getClass(), "Error while loading prediction files (including prediction/defaults.xml)");
+    	}
 
         resetLastChange();
 

--- a/src/main/java/core/model/FormulaFactors.java
+++ b/src/main/java/core/model/FormulaFactors.java
@@ -6,8 +6,6 @@ import core.model.player.IMatchRoleID;
 import core.util.HOLogger;
 import java.io.File;
 import java.io.InputStream;
-import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Date;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;

--- a/src/main/java/core/rating/RatingPredictionConfig.java
+++ b/src/main/java/core/rating/RatingPredictionConfig.java
@@ -1,11 +1,11 @@
 package core.rating;
 
+import core.file.FileLoader;
 import core.util.HOLogger;
 
 import java.io.BufferedReader;
 import java.io.File;
-import java.io.FileNotFoundException;
-import java.io.FileReader;
+import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.util.ArrayList;
 import java.util.Date;
@@ -75,35 +75,27 @@ public class RatingPredictionConfig {
     	else {
     		ArrayList<String> list = new ArrayList<String>();
     		try {
-    			BufferedReader br = null;
-    			final File predFile = new File(predConfigFile);
-    			if (predFile.exists()) {
-    				br = new BufferedReader(new FileReader(predFile));
+    			InputStream predictionIS = FileLoader.instance().getFileInputStream(new String[]{predConfigFile, predDir + "/predictionTypes.conf"});
+    			if (predictionIS==null) {
+    				HOLogger.instance().debug(RatingPredictionConfig.class, "Error while loading: " + predConfigFile + ", " + predDir + "/predictionTypes.conf");
     			} else {
-    				try {
-						final ClassLoader loader = RatingPredictionConfig.class.getClassLoader();
-						br = new BufferedReader(new InputStreamReader((loader.getResourceAsStream(predDir + "/predictionTypes.conf"))));
-					} catch (Exception e) {
-						HOLogger.instance().debug(RatingPredictionConfig.class, "Error while loading : " + e);
-					}
-    			}
-    			while (br != null && br.ready()) {
-    				String line = br.readLine();
-    				// Remove Comments
-    				line = line.replaceFirst("#.*", "");
-    				// Trim
-    				line = line.trim();
-    				if (line.length() != 0) {
-    					list.add(line);
-    				}
+    				BufferedReader br = new BufferedReader(new InputStreamReader(predictionIS));
+    				while (br != null && br.ready()) {
+        				String line = br.readLine();
+        				// Remove Comments
+        				line = line.replaceFirst("#.*", "");
+        				// Trim
+        				line = line.trim();
+        				if (line.length() != 0) {
+        					list.add(line);
+        				}
+        			}
     			}
     			HOLogger.instance().debug(RatingPredictionConfig.class, "Found predictionTypes: "+list);
     			allPredictionNames = new String[list.size()];
     			for (int i=0; i < allPredictionNames.length; i++) {
     				allPredictionNames[i] = list.get(i);
     			}
-    		} catch (FileNotFoundException e) {
-    			HOLogger.instance().error(RatingPredictionConfig.class, "File not found: "+predConfigFile);
     		} catch (Exception e) {
     			e.printStackTrace();
     		}

--- a/src/main/java/core/rating/RatingPredictionParameter.java
+++ b/src/main/java/core/rating/RatingPredictionParameter.java
@@ -5,8 +5,6 @@ import core.util.HOLogger;
 
 import java.io.BufferedReader;
 import java.io.File;
-import java.io.FileNotFoundException;
-import java.io.FileReader;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.util.Enumeration;

--- a/src/main/java/core/rating/RatingPredictionParameter.java
+++ b/src/main/java/core/rating/RatingPredictionParameter.java
@@ -1,11 +1,13 @@
 package core.rating;
 
+import core.file.FileLoader;
 import core.util.HOLogger;
 
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.FileReader;
+import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.util.Enumeration;
 import java.util.Hashtable;
@@ -39,49 +41,40 @@ public class RatingPredictionParameter  {
 				allProps.clear();
 				HOLogger.instance().debug(this.getClass(), "(Re-)initializing prediction parameters: "+newFilename);
 				
-				//BufferedReader br = new BufferedReader(new FileReader(newFilename));
-				BufferedReader br = null;
-    			final File predFile = new File(newFilename);
-    			if (predFile.exists()) {
-    				br = new BufferedReader(new FileReader(predFile));
-    			} else {
-    				try {
-						final ClassLoader loader = RatingPredictionConfig.class.getClassLoader();
-						br = new BufferedReader(new InputStreamReader((loader.getResourceAsStream(newFilename))));
-					} catch (Exception e) {
-						HOLogger.instance().debug(RatingPredictionConfig.class, "Error loading " + newFilename + ": " + e);
-					}
-    			}
+				InputStream predictionIS = FileLoader.instance().getFileInputStream(newFilename);
+				if (predictionIS==null) {
+					HOLogger.instance().debug(RatingPredictionConfig.class, "Error while loading: " + newFilename);
+				} else {
+					BufferedReader br = new BufferedReader(new InputStreamReader(predictionIS));
 				
-				String line = null;
-				Properties curProperties = null;
-				while(br != null && (line = br.readLine()) != null) {
-					line = line.toLowerCase(java.util.Locale.ENGLISH);
-					// # begins a Comment
-					line = line.replaceFirst ("#.*", "");
-					// Trim
-					line = line.trim();
-					if (line.startsWith("[")) {
-						// new Section
-						String sectionName = line.replaceFirst ("^\\[(.*)\\].*", "$1");
-						if (allProps.containsKey(sectionName)) {
-							curProperties = allProps.get(sectionName);
-						} else {
-							curProperties = new Properties();
-							allProps.put(sectionName, curProperties);
+					String line = null;
+					Properties curProperties = null;
+					while(br != null && (line = br.readLine()) != null) {
+						line = line.toLowerCase(java.util.Locale.ENGLISH);
+						// # begins a Comment
+						line = line.replaceFirst ("#.*", "");
+						// Trim
+						line = line.trim();
+						if (line.startsWith("[")) {
+							// new Section
+							String sectionName = line.replaceFirst ("^\\[(.*)\\].*", "$1");
+							if (allProps.containsKey(sectionName)) {
+								curProperties = allProps.get(sectionName);
+							} else {
+								curProperties = new Properties();
+								allProps.put(sectionName, curProperties);
+							}
+						}
+						String temp[] = line.split("=");
+						if (temp.length == 2 && curProperties != null) {
+							String key = temp[0].trim();
+							String value = temp[1].trim();
+							//System.out.println ("Found new property: "+key+" -> "+value);
+							curProperties.setProperty(key, value);
 						}
 					}
-					String temp[] = line.split("=");
-					if (temp.length == 2 && curProperties != null) {
-						String key = temp[0].trim();
-						String value = temp[1].trim();
-						//System.out.println ("Found new property: "+key+" -> "+value);
-						curProperties.setProperty(key, value);
-					}
-				}
 				//            System.out.println ("All Props: "+allProps);
-			} catch (FileNotFoundException e) {
-				HOLogger.instance().error(RatingPredictionConfig.class, "File not found: " + newFilename);
+				}
 			} catch (Exception e) {
 				HOLogger.instance().error(RatingPredictionConfig.class, e);
 			}

--- a/src/main/java/core/training/SkillDrops.java
+++ b/src/main/java/core/training/SkillDrops.java
@@ -1,11 +1,11 @@
 package core.training;
 
-import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Scanner;
 
 import core.constants.player.PlayerSkill;
+import core.file.FileLoader;
 import core.module.config.ModuleConfig;
 import core.util.HOLogger;
 
@@ -234,7 +234,7 @@ public class SkillDrops {
 		try {
 			List<double[]> lines = new ArrayList<double[]>();
 		
-			Scanner fileIn = new Scanner(new File("prediction/skilldrops/" + fileName));
+			Scanner fileIn = new Scanner(FileLoader.instance().getFileInputStream("prediction/skilldrops/" + fileName));
 			while (fileIn.hasNextLine()) {
 			    // read a line, and turn it into the characters
 			    String[] oneLine = fileIn.nextLine().split(",");
@@ -243,6 +243,7 @@ public class SkillDrops {
 			    											+ fileName + ". error in line length");
 			    	return null;
 			    }
+			    fileIn.close();
 			    
 			    double[] doubleLine = new double[oneLine.length];
 			    
@@ -262,7 +263,7 @@ public class SkillDrops {
 														+ fileName + ". wrong number of lines");
 				return null;
 			}
-		
+			
 			return lines.toArray(new double[lines.size()][]);
 		} catch (Exception e) {
 			HOLogger.instance().error(getClass(), "Failed to read skill drop file: " + fileName + ". " + e.getMessage());

--- a/src/main/java/core/training/SkillDrops.java
+++ b/src/main/java/core/training/SkillDrops.java
@@ -1,5 +1,6 @@
 package core.training;
 
+import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Scanner;
@@ -232,18 +233,24 @@ public class SkillDrops {
 	private double[][] readArrayFromFile (String fileName) {
 		
 		try {
+			InputStream fileIS = FileLoader.instance().getFileInputStream("prediction/skilldrops/" + fileName);
+			if (fileIS==null) {
+				HOLogger.instance().error(getClass(), "Failed to open skill drop file: " + fileName);
+				return null;
+			}
+			
 			List<double[]> lines = new ArrayList<double[]>();
 		
-			Scanner fileIn = new Scanner(FileLoader.instance().getFileInputStream("prediction/skilldrops/" + fileName));
+			Scanner fileIn = new Scanner(fileIS);
 			while (fileIn.hasNextLine()) {
 			    // read a line, and turn it into the characters
 			    String[] oneLine = fileIn.nextLine().split(",");
 			    if (oneLine.length != LINE_LENGTH) {
 			    	HOLogger.instance().error(getClass(), "Failed to read skill drop file: " 
 			    											+ fileName + ". error in line length");
-			    	return null;
+			    	fileIn.close();
+				    return null;
 			    }
-			    fileIn.close();
 			    
 			    double[] doubleLine = new double[oneLine.length];
 			    
@@ -258,6 +265,8 @@ public class SkillDrops {
 			    lines.add(doubleLine);
 			
 			}
+			fileIn.close();
+		    
 			if (lines.size() != LINES) {
 				HOLogger.instance().error(getClass(), "Failed to read skill drop file: " 
 														+ fileName + ". wrong number of lines");


### PR DESCRIPTION
Changes proposed in this pull request:
 - fixes issues #205 and #204 

Description
This introduce a new FileLoader that should be used in order to load resources (e.g. configuration files). The FileLoader searches requested files in the filesystem (e.g. for predictions) and, if they are not available, search for them into the HO.jar (or any other jar accessible by default from the classloader). This is needed because packaging the .app for MacOSX doesn't currently support resources outside JARs.
The FileLoader caches if a file has not been found, or where it should be searched next time it is loaded.

To be tested:
- set a log level to Debug
- first time a file is loaded via the FileLoader, the result (inside jar, outside jar, not found) is logged
Current tests passed before PR:
- MacOSX .app
- Zip distribution (trying to place needed resources bot inside and then outside the JAR)
