### PR TITLE
Fix NPE when opening League details panel

### DIFF
--- a/docs/release_notes(dev).md
+++ b/docs/release_notes(dev).md
@@ -14,6 +14,7 @@ Changelist HO! 2.0
  - sorting issue after change filter in Arena section
  - bug due to match report size larger than db threshold
  - invalid select statement and duplicated IDs in matches tab
+ - NullPointerException when selecting the League details tab
 
 ## Changed
  - ...

--- a/src/main/java/module/series/MatchDayPanel.java
+++ b/src/main/java/module/series/MatchDayPanel.java
@@ -121,10 +121,9 @@ final class MatchDayPanel extends JPanel implements ActionListener {
         if (paarung != null) {
             gameFinishTime = paarung.getDatum().getTime();
             gameFinishTime = gameFinishTime + 3 * 60 * 60 * 1000L; //assuming 3 hours to make sure the game is finished
-            gameFinished = paarung.hatStattgefunden() == true || gameFinishTime < nowTime;
+            gameFinished = paarung.hatStattgefunden() || gameFinishTime < nowTime;
         }
 
-        gameFinished = paarung.hatStattgefunden() || gameFinishTime < nowTime;
         // Hat das Spiel schon stattgefunden
         if ((paarung != null) && gameFinished) {
             //Match already in the database


### PR DESCRIPTION
`paarung` may not be initialised when the panel is loaded.  This exact
same statement appears above within the null check.

1. changes proposed in this pull request:

  The latest release of HO cannot display the League details tab, and display the following error:

```
11:14:56 [Error]   core.util.ExceptionHandler: java.lang.NullPointerException
11:14:56 [Error]   core.util.ExceptionHandler: module.series.MatchDayPanel.setMatchButton(MatchDayPanel.java:127)
11:14:56 [Error]   core.util.ExceptionHandler: module.series.MatchDayPanel.fillLabels(MatchDayPanel.java:164)
11:14:56 [Error]   core.util.ExceptionHandler: module.series.MatchDayPanel.initComponents(MatchDayPanel.java:340)
11:14:56 [Error]   core.util.ExceptionHandler: module.series.MatchDayPanel.<init>(MatchDayPanel.java:61)
11:14:56 [Error]   core.util.ExceptionHandler: module.series.SeriesPanel.initSpielPlan(SeriesPanel.java:250)
11:14:56 [Error]   core.util.ExceptionHandler: module.series.SeriesPanel.initComponents(SeriesPanel.java:226)
11:14:56 [Error]   core.util.ExceptionHandler: module.series.SeriesPanel.initialize(SeriesPanel.java:50)
11:14:56 [Error]   core.util.ExceptionHandler: core.gui.comp.panel.LazyImagePanel.callInitialize(LazyImagePanel.java:147)
11:14:56 [Error]   core.util.ExceptionHandler: core.gui.comp.panel.LazyImagePanel.access$300(LazyImagePanel.java:13)
11:14:56 [Error]   core.util.ExceptionHandler: core.gui.comp.panel.LazyImagePanel$2.hierarchyChanged(LazyImagePanel.java:134)
11:14:56 [Error]   core.util.ExceptionHandler: java.awt.Component.processHierarchyEvent(Component.java:6702)
11:14:56 [Error]   core.util.ExceptionHandler: java.awt.Component.processEvent(Component.java:6321)
11:14:56 [Error]   core.util.ExceptionHandler: java.awt.Container.processEvent(Container.java:2236)
11:14:56 [Error]   core.util.ExceptionHandler: java.awt.Component.dispatchEventImpl(Component.java:4891)
11:14:56 [Error]   core.util.ExceptionHandler: java.awt.Container.dispatchEventImpl(Container.java:2294)
11:14:56 [Error]   core.util.ExceptionHandler: java.awt.Component.dispatchEvent(Component.java:4713)
11:14:56 [Error]   core.util.ExceptionHandler: java.awt.Component.createHierarchyEvents(Component.java:5551)
11:14:56 [Error]   core.util.ExceptionHandler: java.awt.Container.createHierarchyEvents(Container.java:1445)
11:14:56 [Error]   core.util.ExceptionHandler: java.awt.Component.show(Component.java:1641)
11:14:56 [Error]   core.util.ExceptionHandler: java.awt.Component.show(Component.java:1673)
11:14:56 [Error]   core.util.ExceptionHandler: java.awt.Component.setVisible(Component.java:1625)
11:14:56 [Error]   core.util.ExceptionHandler: javax.swing.JComponent.setVisible(JComponent.java:2644)
11:14:56 [Error]   core.util.ExceptionHandler: javax.swing.JTabbedPane.fireStateChanged(JTabbedPane.java:394)
11:14:56 [Error]   core.util.ExceptionHandler: javax.swing.JTabbedPane$ModelListener.stateChanged(JTabbedPane.java:270)
11:14:56 [Error]   core.util.ExceptionHandler: javax.swing.DefaultSingleSelectionModel.fireStateChanged(DefaultSingleSelectionModel.java:132)
11:14:56 [Error]   core.util.ExceptionHandler: javax.swing.DefaultSingleSelectionModel.setSelectedIndex(DefaultSingleSelectionModel.java:67)
11:14:56 [Error]   core.util.ExceptionHandler: javax.swing.JTabbedPane.setSelectedIndexImpl(JTabbedPane.java:616)
11:14:56 [Error]   core.util.ExceptionHandler: javax.swing.JTabbedPane.setSelectedIndex(JTabbedPane.java:591)
11:14:56 [Error]   core.util.ExceptionHandler: javax.swing.plaf.basic.BasicTabbedPaneUI$Handler.mousePressed(BasicTabbedPaneUI.java:3647)
(. . .)
``` 

2. changelog and release_notes ...

 - [x] have been updated
 - [ ] do not require update


3. [Optional] suggested person to review this PR @___

@akasolace 