### PR TITLE
Fix macos zip generation following #353.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -163,6 +163,7 @@ distributions {
 
 // Configure macAppBundle task =======================
 macAppBundle {
+    appName = 'HO'
     mainClassName = "HOLauncher"
     icon = "${project.ext.osx_app_dir_sourcedir}/HO.icns"
     bundleJRE = false // true #issue-198
@@ -255,13 +256,13 @@ task makeAll(type: GradleBuild) {
     description 'Create ZipDistribution, Windows, MacOS and Linux binaries'
     tasks = ['cleanBuild', 'pushmd', 'markdownToHtml', 'pullhtml', 'poeditorPull', 'createLanguageFileList',
              'installDist', 'AddResourcesInDistrib', 'makeWinInstaller', 'ZipDistribution', 'buildDeb',
-             'finishDeb', 'buildRpm', 'finishRpm', 'osXjar', 'createApp', 'AddResourcesAndZipMacApp', 'updatebuildreferences', 'compute_sha_sums']
+             'finishDeb', 'buildRpm', 'finishRpm', 'osXjar', 'createApp', 'ZipMacAppDistribution', 'updatebuildreferences', 'compute_sha_sums']
 }
 
 task makeosX(type: GradleBuild) {
     group 'ho'
     description 'Create ZipDistribution and MacOS binaries'
-    tasks = ['init', 'installDist', 'AddResourcesInDistrib', 'ZipDistribution', 'osXjar', 'createApp', 'AddResourcesAndZipMacApp']
+    tasks = ['init', 'installDist', 'AddResourcesInDistrib', 'ZipDistribution', 'osXjar', 'createApp', 'ZipMacAppDistribution']
 }
 
 task updatebuildreferences(){
@@ -490,7 +491,7 @@ task finishRpm{
             from("${buildDir}/distributions")
             include("*.rpm")
             into("${buildDir}/artefacts")
-            rename { filename -> filename.replace('.noarch', '').replace('~','-').replace('ho','HO')}
+            rename { filename -> filename.replace('.noarch', '').replace('~','-').replace('ho','HO') }
             }
         }
     }
@@ -507,7 +508,7 @@ task ZipDistribution(type: Zip) {
     }
 
 
-task AddResourcesAndZipMacApp {
+task AddResourcesMacApp {
     dependsOn 'init', 'createApp'
     doLast {
 	    def baseMacAppDir = "${buildDir}\\macApp\\${project.macAppBundle.appName}.app"
@@ -519,19 +520,17 @@ task AddResourcesAndZipMacApp {
         }
         delete "${macAppDir}\\hamcrest-core-1.3.jar"
         delete "${macAppDir}\\junit-4.12.jar"
-
-        println("zipping MacApp distribution")
-        task(ZipMacAppDistribution, type: Tar) {
-            archiveFileName = "${project.macAppBundle.appName}_${project.version}_macOS.zip"
-            destinationDirectory = file("${project.ext.target_dir}")
-            from ("${buildDir}\\macApp") {exclude("**\\JavaAppLauncher")}
-            from ("${buildDir}\\macApp") {
-                include("**\\JavaAppLauncher")
-                fileMode=0755}
-        }
-
     }
+}
 
+task ZipMacAppDistribution(type: Tar, dependsOn: AddResourcesMacApp) {
+    println("zipping MacApp distribution")
+    archiveName = "${project.macAppBundle.appName}_${project.version}_macOS.zip"
+    destinationDir = file("${project.ext.target_dir}")
+    from ("${buildDir}\\macApp") {exclude("**\\JavaAppLauncher")}
+    from ("${buildDir}\\macApp") {
+        include("**\\JavaAppLauncher")
+        fileMode=0755}
 }
 
 task createLanguageFileList()  {


### PR DESCRIPTION
The `execute` method was not called any more on the nested task in
`AddResourcesAndZipMacApp` so the nested task was not being executed
any more.  Digging deeper, it seems like `execute` does not exist
more.

The workaround is to split the task into tasks, one depending on each
other.  This fixes #359.

1. changes proposed in this pull request:
 
   - fixes issue #359 
 
2. changelog and release_notes ...

 - [ ] have been updated
 - [x] do not require update


3. [Optional] suggested person to review this PR @___

@akasolace — would you be able to verify whether this fixes on your side?  Let me know if you're still having problems...