### PR TITLE
Fix #350

### DIFF
--- a/src/main/java/core/gui/model/UserColumnFactory.java
+++ b/src/main/java/core/gui/model/UserColumnFactory.java
@@ -139,12 +139,20 @@ final public class UserColumnFactory {
                 Player player = spielerCBItem.getSpieler();
                 Timestamp matchDate = spielerCBItem.getMatchdetails().getSpielDatum();
                 System.out.println(spielerCBItem.getMatchdate());
-                String ageString = player.getAdjustedAgeFromDate(matchDate);
-                return new ColorLabelEntry(player.getDoubleAgeFromDate(matchDate),
-                        ageString,
-                        ColorLabelEntry.FG_STANDARD,
-                        ColorLabelEntry.BG_STANDARD,
-                        SwingConstants.LEFT);
+
+                if (matchDate != null) {
+                    String ageString = player.getAdjustedAgeFromDate(matchDate);
+                    return new ColorLabelEntry(player.getDoubleAgeFromDate(matchDate),
+                            ageString,
+                            ColorLabelEntry.FG_STANDARD,
+                            ColorLabelEntry.BG_STANDARD,
+                            SwingConstants.LEFT);
+                } else {
+                    return new ColorLabelEntry("",
+                            ColorLabelEntry.FG_STANDARD,
+                            ColorLabelEntry.BG_STANDARD,
+                            SwingConstants.LEFT);
+                }
             }
         };
 


### PR DESCRIPTION
It is possible that the database may contain a reference to a match
that has no entry in `MATCHDETAILS`, in which case an
`ArrayIndexOutOfBoundsException` is thrown when trying to display a
player with a ref to that match.

This fix tries to re-download the match details if it realises they
are not present in the db.  If ultimately, no details can be found,
the match is simply skip.  This may not be the place to do this — maybe scanning the db when initialising it at startup would be better?

As a result, there may also be an NPE, as the date of the match is
also not present, so this fix also checks whether the match date is
present when we try to calculate the age of the player at the time.

I have tried to keep tabs vs. spaces in the respective files.  Any preference for future reference?

1. changes proposed in this pull request:
 
   - fixes issue #350 
   
 
2. changelog and release_notes ...

 - [ ] have been updated
 - [ ] do not require update


3. [Optional] suggested person to review this PR @___

@akasolace 