### PR TITLE
Fix #377

### DIFF
--- a/src/main/java/module/teamAnalyzer/ui/RecapPanel.java
+++ b/src/main/java/module/teamAnalyzer/ui/RecapPanel.java
@@ -164,9 +164,17 @@ public class RecapPanel extends JPanel {
 
             // Columns 12-15
             rowData.add(df.format(matchDetail.getStars()));
-            rowData.add(df.format(matchDetail.getRating().getHatStats()));
+            if (matchDetail.getRating().getHatStats() >= 0) {
+                rowData.add(df.format(matchDetail.getRating().getHatStats()));
+            } else {
+                rowData.add("");
+            }
             rowData.add(df.format(matchDetail.getRating().getSquad()));
-            rowData.add(df.format(matchDetail.getRating().getSquad() / matchDetail.getStars()));
+            if (matchDetail.getStars() != 0.0) {
+                rowData.add(df.format(matchDetail.getRating().getSquad() / matchDetail.getStars()));
+            } else {
+                rowData.add("");
+            }
 
             DecimalFormat df2 = new DecimalFormat("###.##"); //$NON-NLS-1$
 


### PR DESCRIPTION
The number of stars for a team for a walkover is 0.  To calculate the
“SmartSquad” we divide the squad rating by the number of stars, which
results in a divide by 0 which returns `NaN`.  Number formatting `NaN`
was causing an invalid character.

We also do not display the HatStats if it is negative.

![Screenshot 2020-02-06 at 21 46 44](https://user-images.githubusercontent.com/114285/73982732-bb6b9500-492c-11ea-837e-025ad6036c78.png)


1. changes proposed in this pull request:
 
   - fixes issue #377 
2. changelog and release_notes ...

 - [ ] have been updated
 - [ ] do not require update


3. [Optional] suggested person to review this PR @akasolace 
