### PR TITLE
future trainings marking

### DIFF
--- a/docs/release_notes(beta).md
+++ b/docs/release_notes(beta).md
@@ -61,6 +61,7 @@ Changelist HO! 2.1
   - Fix training for secondary cups #306
   - Track experience acquisition #199
   - Fix training forecast displaying wrong skill up #368
+  - Fix the trainee marking of future training plan #296
 
 
 ## Misc

--- a/docs/release_notes(dev).md
+++ b/docs/release_notes(dev).md
@@ -61,6 +61,7 @@ Changelist HO! 2.1
   - Fix training for secondary cups #306
   - Track experience acquisition #199
   - Fix training forecast displaying wrong skill up #368
+  - Fix the trainee marking of future training plan #296
 
 
 ## Misc

--- a/src/main/java/core/training/FutureTrainingManager.java
+++ b/src/main/java/core/training/FutureTrainingManager.java
@@ -80,6 +80,7 @@ public class FutureTrainingManager {
 		int position = HelperWrapper.instance().getPosition(player.getIdealPosition());
 		// Iterate thru all the future training weeks
 		for (int index = startWeekNumber; index <= finalWeekNumber; index++) {
+			int trainingSpeed=0;
 			weeksPassed++;
 			TrainingPerWeek tw = this.futureTrainings.get(index-1);
 			int trType = tw.getTrainingType();
@@ -181,10 +182,12 @@ public class FutureTrainingManager {
 				// Depending on the type of training, update the proper skill with the provided training points
 							
 				processTraining(wt, trp, tw);
+				if ( this.trainingSpeed < trainingSpeed) {
+					this.trainingSpeed = trainingSpeed;
+				}
 			}
 		}		
-		trainingSpeed /= weeksPassed;
-		FuturePlayer fp = new FuturePlayer();				
+		FuturePlayer fp = new FuturePlayer();
 		fp.setAttack(getFinalValue(PlayerSkill.SCORING));		
 		fp.setCross(getFinalValue(PlayerSkill.WINGER));
 		fp.setDefense(getFinalValue(PlayerSkill.DEFENDING));

--- a/src/main/resources/changelog.md
+++ b/src/main/resources/changelog.md
@@ -59,6 +59,7 @@ If you find a bug, please open an issue on [GitHub](https://github.com/akasolace
   - Fix training for secondary cups #306
   - Track experience acquisition #199
   - Fix training forecast displaying wrong skill up #368
+  - Fix the trainee marking of future training plan #296
 
 
 ## Misc

--- a/src/main/resources/release_notes.md
+++ b/src/main/resources/release_notes.md
@@ -61,6 +61,7 @@ Changelist HO! 2.1
   - Fix training for secondary cups #306
   - Track experience acquisition #199
   - Fix training forecast displaying wrong skill up #368
+ - Fix the trainee marking of future training plan #296  
 
 
 ## Misc


### PR DESCRIPTION
1. changes proposed in this pull request:
 
   - fixes issue #296   

uses maximum trainingsspeed instead of average for marking trainees.
   

3. [Optional] suggested person to review this PR @akasolace 
