### PR TITLE
bug#415 fix match order error if penalty takers list is incomplete

### DIFF
--- a/src/main/java/module/lineup/Lineup.java
+++ b/src/main/java/module/lineup/Lineup.java
@@ -1196,6 +1196,10 @@ public class Lineup{
 
 	public void setPenaltyTakers(List<MatchRoleID> positions) {
 		this.penaltyTakers = new ArrayList<MatchRoleID>(positions);
+		// chpp match order requires exactly 11 penalty takers
+		for ( int i=this.penaltyTakers.size(); i<11; i++){
+			this.penaltyTakers.add(new MatchRoleID(0,0,IMatchRoleID.NORMAL));
+		}
 	}
 
 	/**


### PR DESCRIPTION
(cherry picked from commit 74deb0909560c8447ee0241b9499c72ee1d3b04c)

1. changes proposed in this pull request:
 
   - fixes issue #415 
 

 - [ ] have been updated
 - [x] do not require update


