### PR TITLE
Descending sort when sorting by “Best Position.”

### DIFF
--- a/src/main/java/module/lineup/AustellungSpielerTable.java
+++ b/src/main/java/module/lineup/AustellungSpielerTable.java
@@ -147,11 +147,13 @@ public final class AustellungSpielerTable extends JTable implements core.gui.Ref
 		setOpaque(false);
 
 		if (tableModel == null) {
-			tableModel = UserColumnController.instance().getLineupModel();// ();
+			tableModel = UserColumnController.instance().getLineupModel();
 
 			tableModel.setValues(HOVerwaltung.instance().getModel().getAllSpieler());
 			tableSorter = new TableSorter(tableModel,
-					tableModel.getPositionInArray(UserColumnFactory.ID), getSortSpalte());
+					tableModel.getPositionInArray(UserColumnFactory.ID),
+					getSortSpalte(),
+					tableModel.getPositionInArray(UserColumnFactory.NAME));
 
 			ToolTipHeader header = new ToolTipHeader(getColumnModel());
 			header.setToolTipStrings(tableModel.getTooltips());

--- a/src/main/java/module/playerOverview/PlayerOverviewTable.java
+++ b/src/main/java/module/playerOverview/PlayerOverviewTable.java
@@ -142,7 +142,10 @@ public class PlayerOverviewTable extends JTable implements core.gui.Refreshable 
 		if (tableModel == null) {
 			tableModel = UserColumnController.instance().getPlayerOverviewModel();
 			tableModel.setValues(HOVerwaltung.instance().getModel().getAllSpieler());
-			tableSorter = new TableSorter(tableModel, tableModel.getDisplayedColumns().length - 1, getSortSpalte(), 0);
+			tableSorter = new TableSorter(tableModel,
+					tableModel.getPositionInArray(UserColumnFactory.ID),
+					getSortSpalte(),
+					tableModel.getPositionInArray(UserColumnFactory.NAME));
 
 			ToolTipHeader header = new ToolTipHeader(getColumnModel());
 			header.setToolTipStrings(tableModel.getTooltips());

--- a/src/main/resources/changelog.md
+++ b/src/main/resources/changelog.md
@@ -3,6 +3,9 @@ If you find a bug, please open an issue on [GitHub](https://github.com/akasolace
 
 # Changelist HO! 3.0
 
+## Squad
+  - Fix Sorting by Position #397
+
 ## Matches
   - Match Report: now similar to HT match report  #339
 

--- a/src/main/resources/release_notes.md
+++ b/src/main/resources/release_notes.md
@@ -5,6 +5,9 @@ layout: page
 
 Changelist HO! 3.0
 
+## Squad
+  - Fix Sorting by Position #397
+
 ## League Details
  - Promotion / Demotion status displayed on week 14 and 15 of season. #247
 


### PR DESCRIPTION
This fixes #397 by making sure the default sorting for position is
descending which is the natural sorting for the HT positions.

Note this doesn't address the “remember the sorting” requirement as:
- The requirement was arising for the sorting by position bug,
- The “Default Arrangement” in Preferences > Misc is now honoured for all columns

so there is no more need for that requirement.

![Screenshot 2020-04-05 at 13 22 31](https://user-images.githubusercontent.com/114285/78491707-96cf4600-7740-11ea-8fc3-7c44c46e8955.png)


It also makes some improvements to `TableSorter`:
- Adds some documentation to clarify intent,
- Removes some unused code and general cleanup,
- Changes `Vector` to use `ArrayList`,
- Applies the third-click change to the list of players in “Lineup”

1. changes proposed in this pull request:
 
   - fixes issue #397  

2. changelog and release_notes ...

 - [x] have been updated
 - [ ] do not require update


3. [Optional] suggested person to review this PR

@yaute74 
@akasolace 
