### PR TITLE
Poll status until league promotion status is available.

### DIFF
--- a/src/main/java/module/series/promotion/HttpDataSubmitter.java
+++ b/src/main/java/module/series/promotion/HttpDataSubmitter.java
@@ -61,10 +61,11 @@ public class HttpDataSubmitter implements DataSubmitter {
                     supportedLeagues.add(arr.getAsJsonArray().get(0).getAsInt());
                 }
 
+                response.close();
                 return supportedLeagues;
             }
 
-
+            response.close();
         } catch (Exception e) {
             HOLogger.instance().error(
                     HttpDataSubmitter.class,
@@ -88,9 +89,13 @@ public class HttpDataSubmitter implements DataSubmitter {
 
             Response response = client.newCall(request).execute();
             if (response.isSuccessful()) {
-                callback.apply(response.body().string());
-            }
+                String body = response.body().string();
 
+                response.close();
+                callback.apply(body);
+            } else {
+                response.close();
+            }
         } catch (Exception e) {
             HOLogger.instance().error(
                     HttpDataSubmitter.class,
@@ -179,10 +184,13 @@ public class HttpDataSubmitter implements DataSubmitter {
 
                     HOLogger.instance().info(HttpDataSubmitter.class, "Block locked: " + blockInfo.blockId);
 
+                    response.close();
                     return blockInfo;
                 } else {
                     BlockInfo blockInfo = new BlockInfo();
                     blockInfo.status = obj.get("HTTP Status Code").getAsInt();
+
+                    response.close();
                     return blockInfo;
                 }
             }
@@ -215,7 +223,10 @@ public class HttpDataSubmitter implements DataSubmitter {
                 String promotionStatus = response.body().string();
                 HOLogger.instance().info(HttpDataSubmitter.class, "Status: " + promotionStatus);
 
+                response.close();
                 return promotionStatus;
+            } else {
+                response.close();
             }
 
         } catch (Exception e) {

--- a/src/main/java/module/series/promotion/LeaguePromotionHandler.java
+++ b/src/main/java/module/series/promotion/LeaguePromotionHandler.java
@@ -114,6 +114,32 @@ public class LeaguePromotionHandler extends ChangeEventHandler {
         worker.execute();
     }
 
+    public void pollPromotionStatus() {
+        final SwingWorker<Void, Void> worker = new SwingWorker<Void, Void>() {
+            @Override
+            protected Void doInBackground() {
+                HOLogger.instance().info(LeaguePromotionHandler.class, "Polling until status available");
+
+                boolean polling;
+                do {
+                    LeagueStatus status = fetchLeagueStatus();
+                    polling = (status != LeagueStatus.AVAILABLE);
+
+                    try {
+                        Thread.sleep(5000);
+                    } catch (InterruptedException e) {
+                        HOLogger.instance().warning(LeaguePromotionHandler.class,
+                                "Interrupted Thread: " + e.getMessage());
+                    }
+                } while (polling);
+                fireChangeEvent(new ChangeEvent(LeaguePromotionHandler.this));
+                return null;
+            }
+        };
+
+        worker.execute();
+    }
+
     public BlockInfo lockBlock(int leagueId) {
         DataSubmitter submitter = HttpDataSubmitter.instance();
         return submitter.lockBlock(leagueId);

--- a/src/main/java/module/series/promotion/LeagueStatus.java
+++ b/src/main/java/module/series/promotion/LeagueStatus.java
@@ -4,6 +4,7 @@ public enum LeagueStatus {
 
     AVAILABLE,    // Data is available
     IN_PROGRESS,  // Data being uploaded
+    BEING_PROCESSED, // Data uploaded, being processed.
     NOT_AVAILABLE // Data is not available.
 
 }

--- a/src/main/java/module/series/promotion/PromotionInfoPanel.java
+++ b/src/main/java/module/series/promotion/PromotionInfoPanel.java
@@ -51,6 +51,9 @@ public class PromotionInfoPanel extends JPanel {
                             if (promotionHandler.getLeagueStatus() == LeagueStatus.AVAILABLE) {
                                 final LeaguePromotionInfo promotionStatus = promotionHandler.getPromotionStatus(seriesId, teamId);
                                 createPromotionInfoLabel(promotionStatus);
+                            } else if (promotionHandler.getLeagueStatus() == LeagueStatus.BEING_PROCESSED) {
+                                createBeingProcessedLabel();
+                                promotionHandler.pollPromotionStatus();
                             }
                         }
                     });
@@ -97,6 +100,20 @@ public class PromotionInfoPanel extends JPanel {
         JLabel infoLeagueData = new JLabel(createPromotionStatusDisplayString(promotionStatus));
         infoLeagueData.setFont(defaultFont);
         this.add(infoLeagueData);
+
+        this.revalidate();
+        this.repaint();
+    }
+
+    private void createBeingProcessedLabel() {
+        this.removeAll();
+
+        final Basics basics = DBManager.instance().getBasics(HOVerwaltung.instance().getId());
+        JLabel processingLabel = new JLabel(HOVerwaltung.instance().getLanguageString(
+                "pd_status.download.pending",
+                basics.getLiga()));
+        processingLabel.setFont(defaultFont);
+        this.add(processingLabel);
 
         this.revalidate();
         this.repaint();

--- a/src/main/resources/sprache/English.properties
+++ b/src/main/resources/sprache/English.properties
@@ -1957,3 +1957,4 @@ pd_status.download.warning.message=Do you accept to download the data for your l
 pd_status.download.warning.title=League Data Download
 pd_status.download.unavailable.data=Promotion League Data not available.  Click button to process for your league.
 pd_status.download.unavailable.loading=Promotion League Data not available.  Currently processing, please wait...
+pd_status.download.pending=Calculation is running for league {0}, your promotion status will be available shortly.


### PR DESCRIPTION
1. changes proposed in this pull request:
 
Implement polling of league status during data processing until the Promotion/Demotion status is available. 

![Screenshot 2020-04-08 at 22 08 36](https://user-images.githubusercontent.com/114285/78834119-fa2dd200-79e5-11ea-975c-56c868978408.png)


It also explicitly closes okhttp responses to solve possible “connection was leaked” error.
 
2. changelog and release_notes ...

 - [ ] have been updated
 - [x] do not require update


3. [Optional] suggested person to review this PR @akasolace 
