### PR TITLE
Add option for enabling promotion/demotion manager.

### DIFF
--- a/src/main/java/core/model/UserParameter.java
+++ b/src/main/java/core/model/UserParameter.java
@@ -366,6 +366,9 @@ public final class UserParameter extends Configuration {
     public boolean CombinedRatingChartPanel_Values = false;
     public boolean CombinedRatingChartPanel_HelpLines = false;
 
+    // Promotion/Demotion test
+    public boolean promotionManagerTest = false;
+
     //Alternative Positions
     public float alternativePositionsTolerance = .03f;
 
@@ -633,6 +636,8 @@ public final class UserParameter extends Configuration {
         map.put("CombinedRatingChartPanel_HelpLines", String.valueOf(CombinedRatingChartPanel_HelpLines));
         map.put("alternativePositionsTolerance", String.valueOf(alternativePositionsTolerance));
 
+        map.put("promotionManagerTest", String.valueOf(promotionManagerTest));
+
         return map;
     }
 
@@ -862,6 +867,8 @@ public final class UserParameter extends Configuration {
         CombinedRatingChartPanel_Values = getBooleanValue(values, "CombinedRatingChartPanel_Values");
         CombinedRatingChartPanel_HelpLines = getBooleanValue(values, "CombinedRatingChartPanel_HelpLines");
         alternativePositionsTolerance = getFloatValue(values, "alternativePositionsTolerance");
+
+        promotionManagerTest = getBooleanValue(values, "promotionManagerTest");
     }
 
 }

--- a/src/main/java/core/option/SonstigeOptionenPanel.java
+++ b/src/main/java/core/option/SonstigeOptionenPanel.java
@@ -79,6 +79,7 @@ public final class SonstigeOptionenPanel extends ImagePanel implements ChangeLis
     private SliderPanel m_jslWetterEffekt;
     private SliderPanel m_jslFutureWeeks;
     private SliderPanel m_jslAlternativePositionsTolerance;
+    private JCheckBox m_jcbPromotionStatusTest;
 
     /**
      * Creates a new SonstigeOptionenPanel object.
@@ -102,6 +103,8 @@ public final class SonstigeOptionenPanel extends ImagePanel implements ChangeLis
     public final void itemStateChanged(ItemEvent itemEvent) {
         // Kein Selected Event!
         core.model.UserParameter.temp().zahlenFuerSkill = m_jchZahlenBewertung.isSelected();
+        UserParameter.temp().promotionManagerTest = m_jcbPromotionStatusTest.isSelected();
+
         if (itemEvent.getStateChange() == java.awt.event.ItemEvent.SELECTED) {
             core.model.UserParameter.temp().faktorGeld = ((GeldFaktorCBItem) m_jcbWaehrung.getSelectedItem()).getFaktor();
             core.model.UserParameter.temp().TimeZoneDifference = ((CBItem) m_jcbTimeZoneDifference.getSelectedItem()).getId();
@@ -110,8 +113,9 @@ public final class SonstigeOptionenPanel extends ImagePanel implements ChangeLis
             core.model.UserParameter.temp().standardsortierung = ((CBItem) m_jcbSortierung.getSelectedItem()).getId();
             core.model.UserParameter.temp().skin = ((String) m_jcbSkin.getSelectedItem());
         }
-        if ((!core.model.UserParameter.temp().sprachDatei.equals(core.model.UserParameter.instance().sprachDatei))
-                || (core.model.UserParameter.temp().TimeZoneDifference != core.model.UserParameter.instance().TimeZoneDifference))
+        if (!core.model.UserParameter.temp().sprachDatei.equals(core.model.UserParameter.instance().sprachDatei)
+                || (core.model.UserParameter.temp().TimeZoneDifference != core.model.UserParameter.instance().TimeZoneDifference)
+                || (UserParameter.temp().promotionManagerTest != UserParameter.instance().promotionManagerTest))
             OptionManager.instance().setRestartNeeded();
         if (core.model.UserParameter.temp().zahlenFuerSkill != core.model.UserParameter.instance().zahlenFuerSkill)
             OptionManager.instance().setReInitNeeded();
@@ -146,7 +150,7 @@ public final class SonstigeOptionenPanel extends ImagePanel implements ChangeLis
      * Init components
      */
     private void initComponents() {
-        setLayout(new GridLayout(12, 1, 4, 4));
+        setLayout(new GridLayout(13, 1, 4, 4));
 
         m_jslDeadline = new SliderPanel(HOVerwaltung.instance().getLanguageString("TransferWecker"), 60, 0, 1f / 60000f, 1.0f, 120);
         m_jslDeadline.setToolTipText(HOVerwaltung.instance().getLanguageString("tt_Optionen_TransferWecker"));
@@ -233,5 +237,10 @@ public final class SonstigeOptionenPanel extends ImagePanel implements ChangeLis
         m_jslAlternativePositionsTolerance.addChangeListener(this);
         add(m_jslAlternativePositionsTolerance);
 
+        m_jcbPromotionStatusTest = new JCheckBox(HOVerwaltung.instance().getLanguageString("PMStatusTest"));
+        m_jcbPromotionStatusTest.setOpaque(false);
+        m_jcbPromotionStatusTest.setSelected(UserParameter.temp().promotionManagerTest);
+        m_jcbPromotionStatusTest.addItemListener(this);
+        add(m_jcbPromotionStatusTest);
     }
 }

--- a/src/main/java/module/series/promotion/LeaguePromotionHandler.java
+++ b/src/main/java/module/series/promotion/LeaguePromotionHandler.java
@@ -6,6 +6,7 @@ import com.google.gson.JsonObject;
 import core.db.DBManager;
 import core.gui.event.ChangeEventHandler;
 import core.model.HOVerwaltung;
+import core.model.UserParameter;
 import core.model.misc.Basics;
 import core.module.config.ModuleConfig;
 import core.util.HOLogger;
@@ -49,7 +50,9 @@ public class LeaguePromotionHandler extends ChangeEventHandler {
         List<Integer> supportedLeagues = HttpDataSubmitter.instance().fetchSupportedLeagues();
         int[] activeWeeks = ModuleConfig.instance().getIntArray("PromotionStatus_ActiveWeeks", new int[] { 14, 15 });
         int week = HOVerwaltung.instance().getModel().getBasics().getSpieltag();
-        return Arrays.stream(activeWeeks).boxed().collect(Collectors.toList()).contains(week) && supportedLeagues.contains(seriesId);
+        return UserParameter.instance().promotionManagerTest ||
+                (Arrays.stream(activeWeeks).boxed().collect(Collectors.toList()).contains(week) &&
+                        supportedLeagues.contains(seriesId));
     }
 
     public LeagueStatus getLeagueStatus() {

--- a/src/main/resources/sprache/English.properties
+++ b/src/main/resources/sprache/English.properties
@@ -1989,3 +1989,5 @@ pd_status.download.warning.title=League Data Download
 pd_status.download.unavailable.data=Promotion League Data not available.  Click button to process for your league.
 pd_status.download.unavailable.loading=Promotion League Data not available.  Currently processing, please wait...
 pd_status.download.pending=Calculation is running for league {0}, your promotion status will be available shortly.
+
+PMStatusTest=Promotion Status Test


### PR DESCRIPTION
1. changes proposed in this pull request:

This adds a temporary option in the Preferences > Misc panel to turn on / off the promotion manager functionality to be able to test it outside week 14 & 15.

This option will be removed in later releases.

![Screenshot 2020-04-15 at 22 01 29](https://user-images.githubusercontent.com/114285/79388119-b2b6c100-7f64-11ea-8cf2-dcc4a0d256fb.png)

 
2. changelog and release_notes ...

 - [ ] have been updated
 - [x] do not require update


3. [Optional] suggested person to review this PR @akasolace 
