### PR TITLE
Display form streak using coloured circles.

### DIFF
--- a/src/main/java/core/gui/comp/icon/DrawIcon.java
+++ b/src/main/java/core/gui/comp/icon/DrawIcon.java
@@ -1,0 +1,52 @@
+package core.gui.comp.icon;
+
+import core.gui.theme.HOColorName;
+import core.gui.theme.ThemeManager;
+
+import javax.swing.*;
+import java.awt.*;
+
+/**
+ * Icon that represents either a green upward triangle, or a red downward triangle
+ * based on the direction chosen.
+ *
+ * <p>The triangle is currently used in the table league to show position evolution
+ * in the league.  It cannot be resized as of yet.</p>
+ */
+public class DrawIcon implements Icon {
+    public final static int UPWARD_DIRECTION = 1;
+    public final static int DOWNWARD_DIRECTION = 0;
+
+    private static final Color WIN_COLOR = ThemeManager.getColor(HOColorName.FORM_STREAK_WIN);
+    private static final Color DEFEAT_COLOR = ThemeManager.getColor(HOColorName.FORM_STREAK_DEFEAT);
+
+    private final int direction;
+
+    public DrawIcon(int direction) {
+        this.direction = direction;
+    }
+
+    @Override
+    public void paintIcon(Component c, Graphics g, int x, int y) {
+        Graphics2D g2 = (Graphics2D)g;
+        g2.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON);
+
+        if (direction == UPWARD_DIRECTION) {
+            g2.setColor(WIN_COLOR);
+            g2.fillPolygon(new int[]{12, 20, 16}, new int[]{12, 12, 18}, 3);
+        } else {
+            g2.setColor(DEFEAT_COLOR);
+            g2.fillPolygon(new int[]{12, 20, 16}, new int[]{18, 18, 12}, 3);
+        }
+    }
+
+    @Override
+    public int getIconWidth() {
+        return 10;
+    }
+
+    @Override
+    public int getIconHeight() {
+        return 10;
+    }
+}

--- a/src/main/java/core/gui/theme/HOColorName.java
+++ b/src/main/java/core/gui/theme/HOColorName.java
@@ -7,7 +7,6 @@ package core.gui.theme;
 /**
  * Constants for Colors used in HO.
  * Modules can use them too.
- * @see IGui.getColor(String key)
  */
 public interface HOColorName {
 
@@ -123,6 +122,14 @@ public interface HOColorName {
 	public static final String STAT_LODDAR				= "stat.loddar";
 
 	public static final String MATCHHIGHLIGHT_FAILED_FG	= "matchHighlight.failed.fg";
+
+	public static final String FORM_STREAK_WIN = "form.streak.win";
+	public static final String FORM_STREAK_DRAW = "form.streak.draw";
+	public static final String FORM_STREAK_DEFEAT = "form.streak.defeat";
+	public static final String FORM_STREAK_UNKNOWN = "form.streak.unknown";
+
+	public static final String TABLE_LEAGUE_EVEN = "table.league.even";
+	public static final String TABLE_LEAGUE_ODD = "table.league.odd";
 
 	//lineup
 

--- a/src/main/java/core/gui/theme/ho/HOClassicSchema.java
+++ b/src/main/java/core/gui/theme/ho/HOClassicSchema.java
@@ -465,6 +465,16 @@ public class HOClassicSchema extends Schema implements HOIconName, HOColorName, 
 		put(MATCHESANALYZER_TEAM_TOURNAMENT_NEXT,	new Color(0, 51, 255));
 		put(MATCHESANALYZER_TEAM_TOURNAMENT,		new Color(0, 179, 255));
 		put(MATCHESANALYZER_TEAM_MYTEAM,			"black");
+
+		// Colours for form streak in league details
+		put(FORM_STREAK_WIN, new Color(73, 146, 45));
+		put(FORM_STREAK_DRAW, new Color(111, 111, 111));
+		put(FORM_STREAK_DEFEAT, new Color(224, 51, 51));
+		put(FORM_STREAK_UNKNOWN, new Color(170, 170, 170));
+
+		// Colours for alternating rows in table
+		put(TABLE_LEAGUE_EVEN, Color.WHITE);
+		put(TABLE_LEAGUE_ODD, new Color(240, 240, 240));
 	}
 
 	public Color getDefaultColor(String key) {

--- a/src/main/java/module/series/FormLabel.java
+++ b/src/main/java/module/series/FormLabel.java
@@ -1,0 +1,127 @@
+package module.series;
+
+import core.gui.comp.entry.IHOTableEntry;
+import core.gui.theme.HOColorName;
+import core.gui.theme.ThemeManager;
+import core.model.series.LigaTabellenEintrag;
+
+import javax.swing.*;
+import java.awt.*;
+
+/**
+ * Displays the form streak by drawing circles.  Only a max of 9 circles is drawn.
+ */
+public class FormLabel extends JLabel implements IHOTableEntry {
+
+    public static final Color FG_STANDARD = ThemeManager.getColor(HOColorName.TABLEENTRY_FG);
+    public static final Color BG_STANDARD = ThemeManager.getColor(HOColorName.TABLEENTRY_BG);
+
+    private static final Color WIN_COLOR = ThemeManager.getColor(HOColorName.FORM_STREAK_WIN);
+    private static final Color DRAW_COLOR = ThemeManager.getColor(HOColorName.FORM_STREAK_DRAW);
+    private static final Color DEFEAT_COLOR = ThemeManager.getColor(HOColorName.FORM_STREAK_DEFEAT);
+    private static final Color UNKNOWN_COLOR = ThemeManager.getColor(HOColorName.FORM_STREAK_UNKNOWN);
+
+    private static final int MAX_NUM_FORM_STREAK_ENTRIES = 9;
+
+    private final byte[] form;
+    private Color bgColor;
+
+    public void setBgColor(Color bgColor) {
+        this.bgColor = bgColor;
+    }
+
+    public FormLabel(byte[] form) {
+        this.form = form;
+    }
+
+    @Override
+    public JComponent getComponent(boolean isSelected) {
+        return this;
+    }
+
+    @Override
+    public void clear() {
+    }
+
+    @Override
+    public int compareTo(IHOTableEntry obj) {
+        return 0;
+    }
+
+    @Override
+    public int compareToThird(IHOTableEntry obj) {
+        return 0;
+    }
+
+    @Override
+    public void createComponent() {
+        setForeground(FG_STANDARD);
+        setBackground(BG_STANDARD);
+    }
+
+    @Override
+    public void updateComponent() {
+        setForeground(FG_STANDARD);
+        setBackground(BG_STANDARD);
+    }
+
+    @Override
+    protected void paintComponent(Graphics g) {
+        Graphics2D g2 = (Graphics2D)g;
+        g2.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON);
+
+        g.setColor(bgColor);
+        g.fillRect(0, 0, getWidth(), getHeight());
+        byte[] formDisplayed = getStreakToDisplay();
+
+        for (int i = 0; i < formDisplayed.length; i++) {
+            selectResultColour(g2, formDisplayed[i]);
+            g2.fillOval(10+12*i, 10, 10, 10);
+        }
+    }
+
+    private byte[] getStreakToDisplay() {
+        byte[] formDisplayed;
+        if (form.length > MAX_NUM_FORM_STREAK_ENTRIES) {
+            // Find the first non-unknown result, starting from the end.
+            int index = form.length-1;
+            while (index >= 0 && form[index] == 0) {
+                index--;
+            }
+
+            if (index >= 0) {
+                // pick the last 9 non-unknown results, unless there are fewer.
+                int lengthStreak = Math.min(index+1, MAX_NUM_FORM_STREAK_ENTRIES);
+                formDisplayed = new byte[lengthStreak];
+
+                int start = Math.max(index-MAX_NUM_FORM_STREAK_ENTRIES+1, 0);
+                System.arraycopy(form, start, formDisplayed, 0, lengthStreak);
+            } else {
+                formDisplayed = new byte[0];
+            }
+        } else {
+            // This should never get here—form always contains all 14 matches, incl. the ones yet to play.
+            formDisplayed = form;
+        }
+        return formDisplayed;
+    }
+
+    private void selectResultColour(Graphics2D g2, byte cur) {
+        switch (cur) {
+            case LigaTabellenEintrag.H_SIEG:
+            case LigaTabellenEintrag.A_SIEG:
+                g2.setColor(WIN_COLOR);
+                break;
+            case LigaTabellenEintrag.H_UN:
+            case LigaTabellenEintrag.A_UN:
+                g2.setColor(DRAW_COLOR);
+                break;
+            case LigaTabellenEintrag.H_NIED:
+            case LigaTabellenEintrag.A_NIED:
+                g2.setColor(DEFEAT_COLOR);
+                break;
+            default:
+                g2.setColor(UNKNOWN_COLOR);
+        }
+    }
+}

--- a/src/main/java/module/series/SeriesPanel.java
+++ b/src/main/java/module/series/SeriesPanel.java
@@ -218,11 +218,14 @@ public class SeriesPanel extends LazyImagePanel {
 		toolbarPanel.setPreferredSize(new Dimension(240, 35));
 		panel.add(toolbarPanel, BorderLayout.NORTH);
 
+		JPanel leagueStatsPanel = new ImagePanel(new GridLayout(1, 2));
+		leagueStatsPanel.add(initLigaTabelle());
+		leagueStatsPanel.add(initTabellenverlaufStatistik());
+
 		final JPanel tablePanel = new ImagePanel(new BorderLayout());
-		tablePanel.add(initLigaTabelle(), BorderLayout.NORTH);
+		tablePanel.add(leagueStatsPanel, BorderLayout.NORTH);
 
 		final JPanel historyPanel = new ImagePanel(new BorderLayout());
-		historyPanel.add(initTabellenverlaufStatistik(), BorderLayout.NORTH);
 		historyPanel.add(initSpielPlan(), BorderLayout.CENTER);
 
 		tablePanel.add(historyPanel, BorderLayout.CENTER);

--- a/src/main/java/module/series/SeriesTablePanel.java
+++ b/src/main/java/module/series/SeriesTablePanel.java
@@ -3,7 +3,9 @@ package module.series;
 
 import core.gui.comp.entry.ColorLabelEntry;
 import core.gui.comp.entry.DoppelLabelEntry;
+import core.gui.comp.icon.DrawIcon;
 import core.gui.comp.panel.ImagePanel;
+import core.gui.comp.renderer.HODefaultTableCellRenderer;
 import core.gui.model.VAPTableModel;
 import core.gui.theme.HOColorName;
 import core.gui.theme.ThemeManager;
@@ -14,6 +16,7 @@ import core.util.Helper;
 import core.util.StringUtils;
 
 import javax.swing.*;
+import javax.swing.border.*;
 import javax.swing.event.*;
 import javax.swing.table.*;
 import java.awt.*;
@@ -26,58 +29,26 @@ import java.util.Vector;
 class SeriesTablePanel extends ImagePanel {
 
 	private static final long serialVersionUID = -7087165908899999232L;
+	public static final EmptyBorder EMPTY_BORDER = new EmptyBorder(5, 5, 5, 5);
 	private Color TITLE_BACKGROUND = ThemeManager.getColor(HOColorName.LEAGUE_TITLE_BG);
 	private Color TABLE_BACKGROUND = ThemeManager.getColor(HOColorName.LEAGUE_BG);
 	private Color TABLE_FOREGROUND = ThemeManager.getColor(HOColorName.LEAGUE_FG);
+
+	private Color TABLE_EVEN_ROW = ThemeManager.getColor(HOColorName.TABLE_LEAGUE_EVEN);
+	private Color TABLE_ODD_ROW = ThemeManager.getColor(HOColorName.TABLE_LEAGUE_ODD);
+
 	private final String[] COLUMNNAMES = {
-			HOVerwaltung.instance().getLanguageString("Platz"),
-			HOVerwaltung.instance().getLanguageString("Verein"),
-			HOVerwaltung.instance().getLanguageString("Serie"),
+			"",
+			"",
+			HOVerwaltung.instance().getLanguageString("Punkte_kurz"),
 			HOVerwaltung.instance().getLanguageString("Spiele_kurz"),
 			HOVerwaltung.instance().getLanguageString("SerieAuswaertsSieg"),
 			HOVerwaltung.instance().getLanguageString("SerieAuswaertsUnendschieden"),
 			HOVerwaltung.instance().getLanguageString("SerieAuswaertsNiederlage"),
 			HOVerwaltung.instance().getLanguageString("Tore"),
 			HOVerwaltung.instance().getLanguageString("Differenz_kurz"),
-			HOVerwaltung.instance().getLanguageString("Punkte_kurz"),
-			"",
-
-			HOVerwaltung.instance().getLanguageString("Heim_kurz")
-					+ HOVerwaltung.instance().getLanguageString("SerieAuswaertsSieg"),
-
-			HOVerwaltung.instance().getLanguageString("Heim_kurz")
-					+ HOVerwaltung.instance().getLanguageString("SerieAuswaertsUnendschieden"),
-
-			HOVerwaltung.instance().getLanguageString("Heim_kurz")
-					+ HOVerwaltung.instance().getLanguageString("SerieAuswaertsNiederlage"),
-
-			HOVerwaltung.instance().getLanguageString("Heim_kurz")
-					+ HOVerwaltung.instance().getLanguageString("Tore"),
-
-			HOVerwaltung.instance().getLanguageString("Heim_kurz")
-					+ HOVerwaltung.instance().getLanguageString("Differenz_kurz"),
-
-			HOVerwaltung.instance().getLanguageString("Heim_kurz")
-					+ HOVerwaltung.instance().getLanguageString("Punkte_kurz"),
-			"",
-
-			HOVerwaltung.instance().getLanguageString("Auswaerts_kurz")
-					+ HOVerwaltung.instance().getLanguageString("SerieAuswaertsSieg"),
-
-			HOVerwaltung.instance().getLanguageString("Auswaerts_kurz")
-					+ HOVerwaltung.instance().getLanguageString("SerieAuswaertsUnendschieden"),
-
-			HOVerwaltung.instance().getLanguageString("Auswaerts_kurz")
-					+ HOVerwaltung.instance().getLanguageString("SerieAuswaertsNiederlage"),
-
-			HOVerwaltung.instance().getLanguageString("Auswaerts_kurz")
-					+ HOVerwaltung.instance().getLanguageString("Tore"),
-
-			HOVerwaltung.instance().getLanguageString("Auswaerts_kurz")
-					+ HOVerwaltung.instance().getLanguageString("Differenz_kurz"),
-
-			HOVerwaltung.instance().getLanguageString("Auswaerts_kurz")
-					+ HOVerwaltung.instance().getLanguageString("Punkte_kurz") };
+			HOVerwaltung.instance().getLanguageString("Serie.Last9"),
+	};
 	private JTable seriesTable = new JTable();
 	private Object[][] tableValues;
 	private final Model model;
@@ -127,21 +98,7 @@ class SeriesTablePanel extends ImagePanel {
 	}
 
 	private Color getColor4Row(int row) {
-		switch (row) {
-		case 1:
-			return ThemeManager.getColor(HOColorName.LEAGUE_PROMOTED_BG);
-
-		case 5:
-		case 6:
-			return ThemeManager.getColor(HOColorName.LEAGUE_RELEGATION_BG);
-
-		case 7:
-		case 8:
-			return ThemeManager.getColor(HOColorName.LEAGUE_DEMOTED_BG);
-
-		default:
-			return TABLE_BACKGROUND;// Color.white;
-		}
+		return (row%2 == 0) ? TABLE_EVEN_ROW : TABLE_ODD_ROW;
 	}
 
 	private void setTableColumnWidth() {
@@ -153,8 +110,8 @@ class SeriesTablePanel extends ImagePanel {
 		// Verein
 		columnModel.getColumn(1).setPreferredWidth(Helper.calcCellWidth(200));
 
-		// Serie
-		columnModel.getColumn(2).setPreferredWidth(Helper.calcCellWidth(110));
+		// Punkte
+		columnModel.getColumn(2).setPreferredWidth(Helper.calcCellWidth(30));
 
 		// Spiele
 		columnModel.getColumn(3).setPreferredWidth(Helper.calcCellWidth(25));
@@ -169,63 +126,13 @@ class SeriesTablePanel extends ImagePanel {
 		columnModel.getColumn(6).setPreferredWidth(Helper.calcCellWidth(25));
 
 		// Tore
-		columnModel.getColumn(7).setPreferredWidth(Helper.calcCellWidth(45));
+		columnModel.getColumn(7).setPreferredWidth(Helper.calcCellWidth(50));
 
 		// Differenz
-		columnModel.getColumn(8).setPreferredWidth(Helper.calcCellWidth(30));
+		columnModel.getColumn(8).setPreferredWidth(Helper.calcCellWidth(50));
 
-		// Punkte
-		columnModel.getColumn(9).setPreferredWidth(Helper.calcCellWidth(30));
-
-		// Unterteilung
-		TableColumn column = columnModel.getColumn(10);
-		column.setMaxWidth(Helper.calcCellWidth(5));
-		column.setMinWidth(Helper.calcCellWidth(5));
-		column.setPreferredWidth(Helper.calcCellWidth(5));
-
-		// zuhause
-		// Gewonnen
-		columnModel.getColumn(11).setPreferredWidth(Helper.calcCellWidth(25));
-
-		// Unendschieden
-		columnModel.getColumn(12).setPreferredWidth(Helper.calcCellWidth(25));
-
-		// Verloren
-		columnModel.getColumn(13).setPreferredWidth(Helper.calcCellWidth(25));
-
-		// Tore
-		columnModel.getColumn(14).setPreferredWidth(Helper.calcCellWidth(45));
-
-		// Differenz
-		columnModel.getColumn(15).setPreferredWidth(Helper.calcCellWidth(30));
-
-		// Punkte
-		columnModel.getColumn(16).setPreferredWidth(Helper.calcCellWidth(30));
-
-		// Unterteilung
-		column = columnModel.getColumn(17);
-		column.setMaxWidth(Helper.calcCellWidth(5));
-		column.setMinWidth(Helper.calcCellWidth(5));
-		column.setPreferredWidth(Helper.calcCellWidth(5));
-
-		// auswärts
-		// Gewonnen
-		columnModel.getColumn(18).setPreferredWidth(Helper.calcCellWidth(25));
-
-		// Unendschieden
-		columnModel.getColumn(19).setPreferredWidth(Helper.calcCellWidth(25));
-
-		// Verloren
-		columnModel.getColumn(20).setPreferredWidth(Helper.calcCellWidth(25));
-
-		// Tore
-		columnModel.getColumn(21).setPreferredWidth(Helper.calcCellWidth(45));
-
-		// Differenz
-		columnModel.getColumn(22).setPreferredWidth(Helper.calcCellWidth(30));
-
-		// Punkte
-		columnModel.getColumn(23).setPreferredWidth(Helper.calcCellWidth(30));
+		// Serie
+		columnModel.getColumn(9).setPreferredWidth(Helper.calcCellWidth(140));
 	}
 
 	private void initComponents() {
@@ -238,10 +145,8 @@ class SeriesTablePanel extends ImagePanel {
 		constraints.gridy = 0;
 		constraints.insets = new Insets(4, 4, 4, 4);
 
-		setLayout(new BorderLayout());
-
-		seriesTable.setDefaultRenderer(java.lang.Object.class,
-				new core.gui.comp.renderer.HODefaultTableCellRenderer());
+		seriesTable.setDefaultRenderer(java.lang.Object.class, new HODefaultTableCellRenderer());
+		seriesTable.setRowHeight(30);
 
 		final JPanel panel = new ImagePanel(layout);
 		layout.setConstraints(panel, constraints);
@@ -252,6 +157,8 @@ class SeriesTablePanel extends ImagePanel {
 		constraints.weightx = 1.0;
 		constraints.anchor = GridBagConstraints.NORTH;
 		layout.setConstraints(panel, constraints);
+
+		setLayout(new BorderLayout());
 		add(panel);
 	}
 
@@ -278,14 +185,23 @@ class SeriesTablePanel extends ImagePanel {
 
 		for (int i = 1; i < 9; i++) {
 			final Color bg_Color = getColor4Row(i);
-			tableValues[i][0] = new DoppelLabelEntry(new ColorLabelEntry("",
-					ColorLabelEntry.FG_STANDARD, bg_Color, SwingConstants.RIGHT),
-					new ColorLabelEntry("", ColorLabelEntry.FG_STANDARD, bg_Color,
-							SwingConstants.RIGHT));
-			tableValues[i][1] = new ColorLabelEntry("", ColorLabelEntry.FG_STANDARD, bg_Color,
+
+			final ColorLabelEntry left = new ColorLabelEntry("",
+					ColorLabelEntry.FG_STANDARD, bg_Color, SwingConstants.RIGHT);
+			left.setBorder(EMPTY_BORDER);
+			final ColorLabelEntry right = new ColorLabelEntry("", ColorLabelEntry.FG_STANDARD, bg_Color,
+					SwingConstants.RIGHT);
+			right.setBorder(EMPTY_BORDER);
+			tableValues[i][0] = new DoppelLabelEntry(left, right);
+
+			final ColorLabelEntry teamNameEntry = new ColorLabelEntry("", ColorLabelEntry.FG_STANDARD, bg_Color,
 					SwingConstants.LEFT);
+			teamNameEntry.setBorder(EMPTY_BORDER);
+
+			tableValues[i][1] = teamNameEntry;
+
 			tableValues[i][2] = new ColorLabelEntry("", ColorLabelEntry.FG_STANDARD, bg_Color,
-					SwingConstants.LEFT);
+					SwingConstants.RIGHT);
 			tableValues[i][3] = new ColorLabelEntry("", ColorLabelEntry.FG_STANDARD, bg_Color,
 					SwingConstants.RIGHT);
 			tableValues[i][4] = new ColorLabelEntry("", ColorLabelEntry.FG_STANDARD, bg_Color,
@@ -293,72 +209,49 @@ class SeriesTablePanel extends ImagePanel {
 			tableValues[i][5] = new ColorLabelEntry("", ColorLabelEntry.FG_STANDARD, bg_Color,
 					SwingConstants.RIGHT);
 			tableValues[i][6] = new ColorLabelEntry("", ColorLabelEntry.FG_STANDARD, bg_Color,
-					SwingConstants.RIGHT);
-			tableValues[i][7] = new ColorLabelEntry("", ColorLabelEntry.FG_STANDARD, bg_Color,
 					SwingConstants.CENTER);
+			tableValues[i][7] = new ColorLabelEntry("", ColorLabelEntry.FG_STANDARD, bg_Color,
+					SwingConstants.RIGHT);
 			tableValues[i][8] = new ColorLabelEntry("", ColorLabelEntry.FG_STANDARD, bg_Color,
 					SwingConstants.RIGHT);
 			tableValues[i][9] = new ColorLabelEntry("", ColorLabelEntry.FG_STANDARD, bg_Color,
-					SwingConstants.RIGHT);
-			tableValues[i][10] = new ColorLabelEntry("", ColorLabelEntry.FG_STANDARD,
-					TITLE_BACKGROUND, SwingConstants.RIGHT);
-			tableValues[i][11] = new ColorLabelEntry("", ColorLabelEntry.FG_STANDARD, bg_Color,
-					SwingConstants.RIGHT);
-			tableValues[i][12] = new ColorLabelEntry("", ColorLabelEntry.FG_STANDARD, bg_Color,
-					SwingConstants.RIGHT);
-			tableValues[i][13] = new ColorLabelEntry("", ColorLabelEntry.FG_STANDARD, bg_Color,
-					SwingConstants.RIGHT);
-			tableValues[i][14] = new ColorLabelEntry("", ColorLabelEntry.FG_STANDARD, bg_Color,
-					SwingConstants.CENTER);
-			tableValues[i][15] = new ColorLabelEntry("", ColorLabelEntry.FG_STANDARD, bg_Color,
-					SwingConstants.RIGHT);
-			tableValues[i][16] = new ColorLabelEntry("", ColorLabelEntry.FG_STANDARD, bg_Color,
-					SwingConstants.RIGHT);
-			tableValues[i][17] = new ColorLabelEntry("", ColorLabelEntry.FG_STANDARD,
-					TITLE_BACKGROUND, SwingConstants.RIGHT);
-			tableValues[i][18] = new ColorLabelEntry("", ColorLabelEntry.FG_STANDARD, bg_Color,
-					SwingConstants.RIGHT);
-			tableValues[i][19] = new ColorLabelEntry("", ColorLabelEntry.FG_STANDARD, bg_Color,
-					SwingConstants.RIGHT);
-			tableValues[i][20] = new ColorLabelEntry("", ColorLabelEntry.FG_STANDARD, bg_Color,
-					SwingConstants.RIGHT);
-			tableValues[i][21] = new ColorLabelEntry("", ColorLabelEntry.FG_STANDARD, bg_Color,
-					SwingConstants.CENTER);
-			tableValues[i][22] = new ColorLabelEntry("", ColorLabelEntry.FG_STANDARD, bg_Color,
-					SwingConstants.RIGHT);
-			tableValues[i][23] = new ColorLabelEntry("", ColorLabelEntry.FG_STANDARD, bg_Color,
-					SwingConstants.RIGHT);
+					SwingConstants.LEFT);
+
+			for (int j = 2 ; j < 9 ; j++) {
+				((JLabel)tableValues[i][j]).setBorder(EMPTY_BORDER);
+			}
 		}
 
 		// Model setzen
 		seriesTable.setModel(new VAPTableModel(COLUMNNAMES, tableValues));
-
 		setTableColumnWidth();
 	}
 
 	private void reinitTabelle() {
 		try {
 			if (this.model.getCurrentSeries() != null) {
-				final Font monospacedFont = new Font("monospaced", Font.PLAIN,
-						core.model.UserParameter.instance().schriftGroesse + 1);
-
 				final Vector<LigaTabellenEintrag> tabelleneintraege = this.model.getCurrentSeries()
 						.getTabelle().getEintraege();
 				final int teamid = HOVerwaltung.instance().getModel().getBasics().getTeamId();
 				int j = -1;
 
 				for (int i = 0; i < tabelleneintraege.size(); i++) {
-					final LigaTabellenEintrag eintrag = (LigaTabellenEintrag) tabelleneintraege
-							.get(i);
+					final LigaTabellenEintrag eintrag = tabelleneintraege.get(i);
 
 					if (eintrag.getPunkte() > -1) {
 						j = i + 1;
 
-						((DoppelLabelEntry) tableValues[j][0]).getLinks().setText(
-								eintrag.getPosition() + ".");
+						((DoppelLabelEntry) tableValues[j][0]).getLinks().setText("");
 						((DoppelLabelEntry) tableValues[j][0]).getLinks().setFontStyle(Font.BOLD);
-						((DoppelLabelEntry) tableValues[j][0]).getRechts().setText(
-								"(" + eintrag.getAltePosition() + ")");
+						if (eintrag.getPosition() > eintrag.getAltePosition()) {
+							((DoppelLabelEntry) tableValues[j][0]).getLinks().setIcon(new DrawIcon(DrawIcon.UPWARD_DIRECTION));
+						} else if (eintrag.getPosition() < eintrag.getAltePosition()) {
+							((DoppelLabelEntry) tableValues[j][0]).getLinks().setIcon(new DrawIcon(DrawIcon.DOWNWARD_DIRECTION));
+						}
+
+						((DoppelLabelEntry) tableValues[j][0]).getRechts().setText(eintrag.getPosition() + "");
+						((DoppelLabelEntry) tableValues[j][0]).getRechts().setFontStyle(Font.BOLD);
+
 						((ColorLabelEntry) tableValues[j][1]).setText(eintrag.getTeamName());
 						((ColorLabelEntry) tableValues[j][1]).setFontStyle(Font.BOLD);
 
@@ -369,8 +262,8 @@ class SeriesTablePanel extends ImagePanel {
 							((ColorLabelEntry) tableValues[j][1]).setFGColor(TABLE_FOREGROUND);// );Color.black
 						}
 
-						((ColorLabelEntry) tableValues[j][2]).setText(eintrag.getSerieAsString());
-						((ColorLabelEntry) tableValues[j][2]).setFont(monospacedFont);
+						((ColorLabelEntry) tableValues[j][2]).setText(eintrag.getPunkte() + "");
+						((ColorLabelEntry) tableValues[j][2]).setFontStyle(Font.BOLD);
 						((ColorLabelEntry) tableValues[j][3]).setText(eintrag.getAnzSpiele() + "");
 						((ColorLabelEntry) tableValues[j][4]).setText(eintrag.getG_Siege() + "");
 						((ColorLabelEntry) tableValues[j][5]).setText(eintrag.getG_Un() + "");
@@ -379,26 +272,10 @@ class SeriesTablePanel extends ImagePanel {
 								eintrag.getToreFuer(), eintrag.getToreGegen()));
 						((ColorLabelEntry) tableValues[j][8]).setSpecialNumber(
 								eintrag.getGesamtTorDiff(), false);
-						((ColorLabelEntry) tableValues[j][9]).setText(eintrag.getPunkte() + "");
-						((ColorLabelEntry) tableValues[j][9]).setFontStyle(Font.BOLD);
-						((ColorLabelEntry) tableValues[j][11]).setText(eintrag.getH_Siege() + "");
-						((ColorLabelEntry) tableValues[j][12]).setText(eintrag.getH_Un() + "");
-						((ColorLabelEntry) tableValues[j][13]).setText(eintrag.getH_Nied() + "");
-						((ColorLabelEntry) tableValues[j][14]).setText(StringUtils.getResultString(
-								eintrag.getH_ToreFuer(), eintrag.getH_ToreGegen()));
-						((ColorLabelEntry) tableValues[j][15]).setSpecialNumber(
-								eintrag.getHeimTorDiff(), false);
-						((ColorLabelEntry) tableValues[j][16]).setText(eintrag.getH_Punkte() + "");
-						((ColorLabelEntry) tableValues[j][16]).setFontStyle(Font.BOLD);
-						((ColorLabelEntry) tableValues[j][18]).setText(eintrag.getA_Siege() + "");
-						((ColorLabelEntry) tableValues[j][19]).setText(eintrag.getA_Un() + "");
-						((ColorLabelEntry) tableValues[j][20]).setText(eintrag.getA_Nied() + "");
-						((ColorLabelEntry) tableValues[j][21]).setText(StringUtils.getResultString(
-								eintrag.getA_ToreFuer(), eintrag.getA_ToreGegen()));
-						((ColorLabelEntry) tableValues[j][22]).setSpecialNumber(
-								eintrag.getAwayTorDiff(), false);
-						((ColorLabelEntry) tableValues[j][23]).setText(eintrag.getA_Punkte() + "");
-						((ColorLabelEntry) tableValues[j][23]).setFontStyle(Font.BOLD);
+
+						FormLabel formLabel = new FormLabel(eintrag.getSerie());
+						formLabel.setBgColor(getColor4Row(j));
+						tableValues[j][9] = formLabel;
 					}
 				}
 

--- a/src/main/resources/changelog.md
+++ b/src/main/resources/changelog.md
@@ -22,6 +22,7 @@ If you find a bug, please open an issue on [GitHub](https://github.com/akasolace
   - special events prediction #299
 
 ## League Details
+ - Simplification of league table and screen re-arranged. #238
  - Promotion / Demotion status displayed on week 14 and 15 of season. #247
 
 ## Training 

--- a/src/main/resources/release_notes.md
+++ b/src/main/resources/release_notes.md
@@ -15,6 +15,7 @@ Changelist HO! 3.0
   - Download of current matches are selectable by match type  #290
 
 ## League Details
+ - Simplification of league table and screen re-arranged. #238
  - Promotion / Demotion status displayed on week 14 and 15 of season. #247
 
 ## Training 

--- a/src/main/resources/sprache/English.properties
+++ b/src/main/resources/sprache/English.properties
@@ -663,6 +663,7 @@ FrageFormelwertReset=Do you want to reset Formula-Data?
 Aktuell=Actual
 AktuelleLiga=Current Division
 AndereLiga=Selected Division
+Serie.Last9=Form (Last 9)
 
 Spielplan=Matchlist
 Spiele=Matches


### PR DESCRIPTION
1. changes proposed in this pull request:
 
  Aspects of this were discussed in #238 .
  This displays the form streak as coloured circles, instead of letters, e.g.:

![Screenshot 2020-04-18 at 16 28 06](https://user-images.githubusercontent.com/114285/79642047-263e1580-8193-11ea-9339-e18400c28eab.png)

By default it displays the 9 last results.  If there are fewer, it just does't display the unknown games, e.g.:

![Screenshot 2020-04-18 at 16 28 57](https://user-images.githubusercontent.com/114285/79642066-3f46c680-8193-11ea-8198-a4cc85887a46.png)

(Here all the results are green because I have hardcoded the value for testing)

Note that Home / Away is not visible any more; it is not useful to me, but it could be to others – we could potentially code Home matches with a vertical or horizontal line across the circle, if needs be.
 
2. changelog and release_notes ...

I haven't updated the release notes yet, as this depends on whether we would want to include in the 3.0 beta, or a later version after the 3.0 release (probably better).


3. [Optional] suggested person to review this PR @akasolace 
