### PR TITLE
Add indices to improve Matches tab perf

### DIFF
--- a/src/main/java/core/db/DBManager.java
+++ b/src/main/java/core/db/DBManager.java
@@ -56,7 +56,7 @@ public class DBManager {
 	// -----------------------------------------------------------------
 
 	/** database version */
-	private static final int DBVersion = 300; // DBVersion 26 introduce for HO 3.0 version
+	private static final int DBVersion = 301; // DBVersion 26 introduce for HO 3.0 version
 
 	/** 2004-06-14 11:00:00.0 */
 	public static Timestamp TSIDATE = new Timestamp(1087203600000L);

--- a/src/main/java/core/util/TimeUtils.java
+++ b/src/main/java/core/util/TimeUtils.java
@@ -1,0 +1,24 @@
+package core.util;
+
+
+import java.time.Duration;
+import java.time.Instant;
+
+/**
+ * Execute a task, and display its duration on stdout.
+ */
+public class TimeUtils {
+
+    @FunctionalInterface
+    public interface TimedTask {
+        void execute();
+    }
+
+    public static void runWithTime(TimedTask task) {
+        Instant start = Instant.now();
+        task.execute();
+        Instant end = Instant.now();
+        System.out.println(Duration.between(start, end));
+    }
+
+}


### PR DESCRIPTION
Fixes part of the issues raised in #471.  Matches make various queries
on MATCHHIGHLIGHTS, MATCHDETAILS and MATCHKURZINFO on fields that were
not indexed, causing perf issues.

1. changes proposed in this pull request:
 
   - fixes issue #471 (the Matches tab perf issue)  

2. changelog and release_notes ...

 - [ ] have been updated
 - [x] do not require update

3. [Optional] suggested person to review this PR @akasolace 
