### PR TITLE
Simple `SHUTDOWN` of the database.

### DIFF
--- a/src/main/java/core/db/JDBCAdapter.java
+++ b/src/main/java/core/db/JDBCAdapter.java
@@ -30,13 +30,11 @@ public class JDBCAdapter {
 	public final void disconnect() {
 		try {
 			if (User.getCurrentUser().isHSQLDB()) {
-				m_clStatement.execute("SHUTDOWN COMPACT");
+				m_clStatement.execute("SHUTDOWN");
 			}
 			m_clConnection.close();
 			m_clConnection = null;
 		} catch (Exception e) {
-			// vapEngine.Verwaltung.instance ().writeLog (
-			// "JDBCAdapter.disconnect : " + e.getMessage() );
 			HOLogger.instance().error(getClass(), "JDBCAdapter.disconnect : " + e);
 			m_clConnection = null;
 		}

--- a/src/main/resources/changelog.md
+++ b/src/main/resources/changelog.md
@@ -53,6 +53,8 @@ If you find a bug, please open an issue on [GitHub](https://github.com/akasolace
 - [NEW] new match report mocking HT full report #421
 - [FIX] Matches Overview NPE #396
 - [FIX] NPE when trying to simulate upcoming games #472
+- [FIX] Improved performance when first displaying the tab when the database contains lots of matches #471
+- [FIX] Improved performance when exiting HO when the database is big #471
 
 
 ### Lineup

--- a/src/main/resources/release_notes.md
+++ b/src/main/resources/release_notes.md
@@ -54,6 +54,8 @@ Changelist HO! 3.0
 - [NEW] new match report mocking HT full report #421
 - [FIX] Matches Overview NPE #396
 - [FIX] NPE when trying to simulate upcoming games #472
+- [FIX] Improved performance when first displaying the tab when the database contains lots of matches #471
+- [FIX] Improved performance when exiting HO when the database is big #471
 
 
 ### Lineup


### PR DESCRIPTION
`COMPACT` causes major performance issues when exiting HO, without
significant benefits.  Only using a simple `SHUTDOWN` for now, this
can be turned back on later if needs be.

1. changes proposed in this pull request:
 
   - fixes issue #471 
   
 
2. changelog and release_notes ...

 - [x] have been updated
 - [ ] do not require update


3. [Optional] suggested person to review this PR @akasolace 
