### PR TITLE
fix matchkurzinfo column types for BETA 1 users

### DIFF
--- a/src/main/java/core/db/DBUpdater.java
+++ b/src/main/java/core/db/DBUpdater.java
@@ -115,6 +115,10 @@ final class DBUpdater {
 	private void updateDBv301(int dbVersion, int version) {
 
 		try {
+
+			m_clJDBCAdapter.executeUpdate("ALTER TABLE MATCHESKURZINFO ALTER COLUMN isDerby SET DATA TYPE BOOLEAN");
+			m_clJDBCAdapter.executeUpdate("ALTER TABLE MATCHESKURZINFO ALTER COLUMN isNeutral SET DATA TYPE BOOLEAN");
+
 			if (!columnExistsInTable("EVENT_INDEX", MatchHighlightsTable.TABLENAME)) {
 				m_clJDBCAdapter.executeUpdate("ALTER TABLE MATCHHIGHLIGHTS ADD COLUMN EVENT_INDEX INTEGER");
 			}


### PR DESCRIPTION
follow up of f919b2ecc4cbf3c15aada4ebd6b280a0e6a0de89
This treats the case of uses who have already downloaded 3.0 BETA 1 and that will upgrade to BETA 2