### PR TITLE
Escape player's nickname and surname when inserting.

### DIFF
--- a/src/main/java/core/db/SpielerTable.java
+++ b/src/main/java/core/db/SpielerTable.java
@@ -123,8 +123,8 @@ final class SpielerTable extends AbstractTable {
 						
 			statement.append(player.getSpielerID()).append(",");
 			statement.append("'").append(DBManager.insertEscapeSequences(player.getFirstName())).append("',");
-			statement.append("'").append(player.getNickName()).append("',");
-			statement.append("'").append(player.getLastName()).append("',");
+			statement.append("'").append(DBManager.insertEscapeSequences(player.getNickName())).append("',");
+			statement.append("'").append(DBManager.insertEscapeSequences(player.getLastName())).append("',");
 			statement.append(player.getAlter()).append(",");
 			statement.append(player.getAgeDays()).append(",");
 			statement.append(player.getKondition()).append(",");


### PR DESCRIPTION
The nickname and surname need to be escaped before inserting as they
may contain single quotes, which breaks the insert.

1. changes proposed in this pull request:
 
   - fixes issue #490 
 
2. changelog and release_notes ...

 - [ ] have been updated
 - [x] do not require update


3. [Optional] suggested person to review this PR @akasolace 
