### PR TITLE
Compare team summary to previous one.

### DIFF
--- a/src/main/java/module/playerOverview/SpielerTrainingsVergleichsPanel.java
+++ b/src/main/java/module/playerOverview/SpielerTrainingsVergleichsPanel.java
@@ -143,10 +143,8 @@ public class SpielerTrainingsVergleichsPanel extends ImagePanel
         ChangeEvent changeEvent = new ChangeEvent(this);
         fireChangeEvent(changeEvent);
 
-		// Nur manuelles Update der Tabelle, kein reInit, damit die Sortierung
-		// bleibt.
+		// Manual update of the table, so no reInit to keep the current sorting.
 		HOMainFrame.instance().getSpielerUebersichtPanel().refreshHRFVergleich();
-		// gui.RefreshManager.instance().doReInit();
 	}
 
     /**

--- a/src/main/java/module/playerOverview/TeamSummaryPanel.java
+++ b/src/main/java/module/playerOverview/TeamSummaryPanel.java
@@ -96,7 +96,8 @@ public class TeamSummaryPanel extends ImagePanel implements ChangeListener, Refr
 
     @Override
     public void reInit() {
-        model.setComparisonPlayers(null);
+        model.setComparisonPlayers(model.getPlayers());
+        model.setPlayers(HOVerwaltung.instance().getModel().getAllSpieler());
         display();
     }
 

--- a/src/main/resources/changelog.md
+++ b/src/main/resources/changelog.md
@@ -34,6 +34,7 @@ If you find a bug, please open an issue on [GitHub](https://github.com/akasolace
 
   - [FIX] ordering of best position is now saved on closing #397
   - [NEW] manual adjustment of experience level (similar to other skills) #463
+  - [FIX] Fix team summary comparison after new download from HT #475
 
 
 ### Team Analyser

--- a/src/main/resources/release_notes.md
+++ b/src/main/resources/release_notes.md
@@ -35,6 +35,7 @@ Changelist HO! 3.0
 
   - [FIX] ordering of best position is now saved on closing #397
   - [NEW] manual adjustment of experience level (similar to other skills) #463
+  - [FIX] Fix team summary comparison after new download from HT #475
 
 
 ### Team Analyser


### PR DESCRIPTION
When downloading current details from the HT, the team summary needs
to be reset to display the current details, and be compared to the
previous ones.  Fixes #475.

1. changes proposed in this pull request:
 
   - fixes issue #475 
 
2. changelog and release_notes ...

 - [x] have been updated
 - [ ] do not require update


3. [Optional] suggested person to review this PR @akasolace 

Can you please see if this the behaviour you are expecting after an update?  I am not entirely sure what we would want here after a new download, so for now I am displaying comparison between new team summary and previous one.
