### PR TITLE
Ensure matches are downloaded on the first download.

### DIFF
--- a/src/main/java/module/playerOverview/SpielerDetailPanel.java
+++ b/src/main/java/module/playerOverview/SpielerDetailPanel.java
@@ -364,9 +364,11 @@ public final class SpielerDetailPanel extends ImagePanel implements Refreshable,
         if (m_clPlayer.getLastMatchRating() > 0) {
             m_jpLastMatchRating.setYellowStar(true);
             MatchKurzInfo info = DBManager.instance().getMatchesKurzInfoByMatchID(m_clPlayer.getLastMatchId());
-            m_jpLastMatchRating.setRating((float)m_clPlayer.getLastMatchRating());
-            m_jpLastMatchRating.setMatchInfo(m_clPlayer.getLastMatchDate(), info.getMatchTyp());
-            m_jpLastMatchRating.getLabelMatch();
+            if (info != null) {
+                m_jpLastMatchRating.setRating((float)m_clPlayer.getLastMatchRating());
+                m_jpLastMatchRating.setMatchInfo(m_clPlayer.getLastMatchDate(), info.getMatchTyp());
+                m_jpLastMatchRating.getLabelMatch();
+            }
         }
         m_jpNationality.setIcon(ImageUtilities.getFlagIcon(m_clPlayer.getNationalitaet()));
         if (m_clPlayer.isHomeGrown())


### PR DESCRIPTION
Fixes #516.  This makes sure the details of a team are downloaded
before downloading its matches so that the `teamId` is properly set.
This also adds a null check in `SpielerDetailPanel` following the
recent changes around last match date.

1. changes proposed in this pull request:
 
   - fixes issue #516
 
2. changelog and release_notes ...

 - [ ] have been updated
 - [x] do not require update (fixes an issue on a bug that's not released yet)


3. [Optional] suggested person to review this PR @steffanots @akasolace 
