### PR TITLE
Display playoff opponent in status message.

### DIFF
--- a/src/main/java/module/series/SeriesPanel.java
+++ b/src/main/java/module/series/SeriesPanel.java
@@ -211,7 +211,7 @@ public class SeriesPanel extends LazyImagePanel {
 		printButton.setLocation(255, 5);
 		toolbarPanel.add(printButton);
 
-		promotionInfoPanel.setSize(500, 40);
+		promotionInfoPanel.setSize(650, 40);
 		promotionInfoPanel.setLocation(290, 0);
 		toolbarPanel.add(promotionInfoPanel);
 

--- a/src/main/java/module/series/promotion/PromotionInfoPanel.java
+++ b/src/main/java/module/series/promotion/PromotionInfoPanel.java
@@ -32,7 +32,6 @@ public class PromotionInfoPanel extends JPanel {
         setOpaque(false);
         setLayout(new BoxLayout(this, BoxLayout.LINE_AXIS));
         setBorder(new EmptyBorder(0, 10, 0, 0));
-        setPreferredSize(new Dimension(500, 40));
 
         SwingUtilities.invokeLater(() -> {
 
@@ -121,15 +120,17 @@ public class PromotionInfoPanel extends JPanel {
 
     private String createPromotionStatusDisplayString(LeaguePromotionInfo leaguePromotionInfo) {
         List<String> leagueDetails = Collections.EMPTY_LIST;
+        List<Map<String, String>> teamDetails = Collections.EMPTY_LIST;
         if (!leaguePromotionInfo.teams.isEmpty() && !leaguePromotionInfo.teams.contains(-1)) {
             final DownloadCountryDetails downloadCountryDetails = new DownloadCountryDetails();
 
-            leagueDetails = leaguePromotionInfo.teams
+            teamDetails = leaguePromotionInfo.teams
                     .stream()
-                    .map(teamId -> {
-                        Map<String, String> teamInfo = downloadCountryDetails.getTeamSeries(teamId);
-                        return teamInfo.get("LeagueLevelUnitName");
-                    })
+                    .map(teamId -> downloadCountryDetails.getTeamSeries(teamId))
+                    .collect(Collectors.toList());
+            leagueDetails = teamDetails
+                    .stream()
+                    .map(teamInfo -> teamInfo.get("LeagueLevelUnitName"))
                     .collect(Collectors.toList());
         }
 
@@ -137,7 +138,14 @@ public class PromotionInfoPanel extends JPanel {
             return HOVerwaltung.instance().getLanguageString("pd_status." + leaguePromotionInfo.status.name());
         } else {
             return HOVerwaltung.instance().getLanguageString("pd_status." + leaguePromotionInfo.status.name(),
-                    String.join(", ", leagueDetails));
+                    String.join(", ", leagueDetails),
+                    String.join(", ", teamDetails.stream()
+                            .map(stringStringMap -> stringStringMap.get("TeamName"))
+                            .collect(Collectors.toList())),
+                    String.join(", ", teamDetails.stream()
+                            .map(stringStringMap -> stringStringMap.get("TeamID"))
+                            .collect(Collectors.toList()))
+                    );
         }
     }
 }

--- a/src/main/resources/sprache/English.properties
+++ b/src/main/resources/sprache/English.properties
@@ -1958,8 +1958,8 @@ MatchEvent_805=Weakest team (HTRating) is winning
 # Promotion / Demotion status
 pd_status.NO_CHANGE=No change expected.  You are remaining in the same series.
 pd_status.DIRECT_DEMOTION=You will be demoted to {0}.  Tough luck...
-pd_status.DEMOTION_MATCH_BARRAGE=You will play a playoff to remain in your series.
-pd_status.PROMOTION_MATCH_BARRAGE=You will play a playoff to get promoted to {0}.
+pd_status.DEMOTION_MATCH_BARRAGE=You will play a playoff to remain in your series against {1} ({2}) from series {0}.
+pd_status.PROMOTION_MATCH_BARRAGE=You will play a playoff to get promoted to {0} against {1} ({2}).
 pd_status.DIRECT_PROMOTION=You will be promoted to series {0}.  Well done!
 pd_status.UNKNOWN=Your current promotion/demotion status is unknown...
 pd_status.download.data=Download Country Data


### PR DESCRIPTION
1. changes proposed in this pull request:

For teams playing playoffs for promotion / demotion, the message now displays the opposing team, and the potential new league, for example for those two Irish teams potentially playing each other: 
 
![Screenshot 2020-05-14 at 21 48 09](https://user-images.githubusercontent.com/114285/81985069-ac803700-962d-11ea-8f52-0bd05bee95bc.png)
![Screenshot 2020-05-14 at 21 47 10](https://user-images.githubusercontent.com/114285/81985072-aee29100-962d-11ea-837f-2720f40f3ff7.png)

_Note that this requires changes to two labels in translations._
 
2. changelog and release_notes ...

 - [ ] have been updated
 - [x] do not require update


3. [Optional] suggested person to review this PR @akasolace 
