### PR TITLE
Handle font management identically across themes.

### DIFF
--- a/src/main/java/core/gui/theme/BaseTheme.java
+++ b/src/main/java/core/gui/theme/BaseTheme.java
@@ -1,0 +1,67 @@
+package core.gui.theme;
+
+import core.model.UserParameter;
+
+import javax.swing.*;
+import java.awt.*;
+
+public abstract class BaseTheme implements Theme {
+
+     protected void setFont(int fontSize) {
+        UIDefaults uid = UIManager.getLookAndFeelDefaults();
+        final String fontName = FontUtil.getFontName(UserParameter.instance().sprachDatei);
+        final Font userFont = new Font((fontName != null ? fontName : "SansSerif"), Font.PLAIN, fontSize);
+        final Font boldFont = new Font((fontName != null ? fontName : "SansSerif"), Font.BOLD, fontSize);
+        uid.put("defaultFont", userFont);
+        uid.put("DesktopIcon.font", userFont);
+        uid.put("FileChooser.font", userFont);
+        uid.put("RootPane.font", userFont);
+        uid.put("TextPane.font", userFont);
+        uid.put("FormattedTextField.font", userFont);
+        uid.put("Spinner.font", userFont);
+        uid.put("PopupMenuSeparator.font", userFont);
+        uid.put("Table.font", userFont);
+        uid.put("TextArea.font", userFont);
+        uid.put("Slider.font", userFont);
+        uid.put("InternalFrameTitlePane.font", userFont);
+        uid.put("ColorChooser.font", userFont);
+        uid.put("DesktopPane.font", userFont);
+        uid.put("Menu.font", userFont);
+        uid.put("PasswordField.font", userFont);
+        uid.put("InternalFrame.font", userFont);
+        uid.put("InternalFrame.titleFont", boldFont);
+        uid.put("Button.font", userFont);
+        uid.put("Panel.font", userFont);
+        uid.put("MenuBar.font", userFont);
+        uid.put("ComboBox.font", userFont);
+        uid.put("Tree.font", userFont);
+        uid.put("EditorPane.font", userFont);
+        uid.put("CheckBox.font", userFont);
+        uid.put("ToggleButton.font", userFont);
+        uid.put("TabbedPane.font", userFont);
+        uid.put("TableHeader.font", userFont);
+        uid.put("List.font", userFont);
+        uid.put("PopupMenu.font", userFont);
+        uid.put("ToolTip.font", userFont);
+        uid.put("Separator.font", userFont);
+        uid.put("RadioButtonMenuItem.font", userFont);
+        uid.put("RadioButton.font", userFont);
+        uid.put("ToolBar.font", userFont);
+        uid.put("ScrollPane.font", userFont);
+        uid.put("CheckBoxMenuItem.font", userFont);
+        uid.put("Viewport.font", userFont);
+        uid.put("TextField.font", userFont);
+        uid.put("SplitPane.font", userFont);
+        uid.put("MenuItem.font", userFont);
+        uid.put("OptionPane.font", userFont);
+        uid.put("ArrowButton.font", userFont);
+        uid.put("Label.font", userFont);
+        uid.put("ProgressBar.font", userFont);
+        uid.put("ScrollBar.font", userFont);
+        uid.put("ScrollBarThumb.font", userFont);
+        uid.put("ScrollBarTrack.font", userFont);
+        uid.put("SliderThumb.font", userFont);
+        uid.put("SliderTrack.font", userFont);
+        uid.put("TitledBorder.font", boldFont);
+    }
+}

--- a/src/main/java/core/gui/theme/dark/DarkTheme.java
+++ b/src/main/java/core/gui/theme/dark/DarkTheme.java
@@ -1,20 +1,15 @@
 package core.gui.theme.dark;
 
 
+import core.gui.theme.BaseTheme;
 import core.gui.theme.HOBooleanName;
-import core.gui.theme.Theme;
 import core.gui.theme.ThemeManager;
 import core.model.UserParameter;
 
-import java.util.HashMap;
-import java.util.Map;
-
-public abstract class DarkTheme implements Theme {
+public abstract class DarkTheme extends BaseTheme {
 
     public boolean enableTheme() {
-        Map<String, Object> properties = new HashMap<>();
-        properties.put("fontSize", UserParameter.instance().schriftGroesse);
-
+        setFont(UserParameter.instance().schriftGroesse);
         ThemeManager.instance().put(HOBooleanName.IMAGEPANEL_BG_PAINTED, false);
         return true;
     }

--- a/src/main/java/core/gui/theme/light/SolarizedLightTheme.java
+++ b/src/main/java/core/gui/theme/light/SolarizedLightTheme.java
@@ -2,16 +2,14 @@ package core.gui.theme.light;
 
 import com.github.weisj.darklaf.DarkLaf;
 import com.github.weisj.darklaf.LafManager;
+import core.gui.theme.BaseTheme;
 import core.gui.theme.HOBooleanName;
-import core.gui.theme.Theme;
 import core.gui.theme.ThemeManager;
 import core.model.UserParameter;
 
 import javax.swing.*;
-import java.util.HashMap;
-import java.util.Map;
 
-public class SolarizedLightTheme implements Theme {
+public class SolarizedLightTheme extends BaseTheme {
     public final static String THEME_NAME = "Solarized Light";
 
     /**
@@ -28,9 +26,7 @@ public class SolarizedLightTheme implements Theme {
             LafManager.setTheme(new com.github.weisj.darklaf.theme.SolarizedLightTheme());
             UIManager.setLookAndFeel(DarkLaf.class.getCanonicalName());
 
-            Map<String, Object> properties = new HashMap<>();
-            properties.put("fontSize", UserParameter.instance().schriftGroesse);
-
+            setFont(UserParameter.instance().schriftGroesse);
             ThemeManager.instance().put(HOBooleanName.IMAGEPANEL_BG_PAINTED, false);
             return true;
         } catch (Exception e) {

--- a/src/main/java/core/gui/theme/nimbus/NimbusTheme.java
+++ b/src/main/java/core/gui/theme/nimbus/NimbusTheme.java
@@ -18,7 +18,7 @@ import javax.swing.plaf.ColorUIResource;
 import javax.swing.plaf.DimensionUIResource;
 
 
-public class NimbusTheme implements Theme {
+public class NimbusTheme extends BaseTheme {
 
 	public final static String THEME_NAME = "Nimbus";
 
@@ -60,62 +60,9 @@ public class NimbusTheme implements Theme {
 				} else {
 					UIManager.setLookAndFeel(nimbus.getClassName());
 				}
-				
+
+				setFont(fontSize);
 				UIDefaults uid = UIManager.getLookAndFeelDefaults();
-				final String fontName = FontUtil.getFontName(UserParameter.instance().sprachDatei);
-				final Font userFont = new Font((fontName != null ? fontName : "SansSerif"), Font.PLAIN, fontSize);
-				final Font boldFont = new Font((fontName != null ? fontName : "SansSerif"), Font.BOLD, fontSize);
-				uid.put("defaultFont", userFont);
-				uid.put("DesktopIcon.font", userFont);
-				uid.put("FileChooser.font", userFont);
-				uid.put("RootPane.font", userFont);
-				uid.put("TextPane.font", userFont);
-				uid.put("FormattedTextField.font", userFont);
-				uid.put("Spinner.font", userFont);
-				uid.put("PopupMenuSeparator.font", userFont);
-				uid.put("Table.font", userFont);
-				uid.put("TextArea.font", userFont);
-				uid.put("Slider.font", userFont);
-				uid.put("InternalFrameTitlePane.font", userFont);
-				uid.put("ColorChooser.font", userFont);
-				uid.put("DesktopPane.font", userFont);
-				uid.put("Menu.font", userFont);
-				uid.put("PasswordField.font", userFont);
-				uid.put("InternalFrame.font", userFont);
-				uid.put("InternalFrame.titleFont", boldFont);
-				uid.put("Button.font", userFont);
-				uid.put("Panel.font", userFont);
-				uid.put("MenuBar.font", userFont);
-				uid.put("ComboBox.font", userFont);
-				uid.put("Tree.font", userFont);
-				uid.put("EditorPane.font", userFont);
-				uid.put("CheckBox.font", userFont);
-				uid.put("ToggleButton.font", userFont);
-				uid.put("TabbedPane.font", userFont);
-				uid.put("TableHeader.font", userFont);
-				uid.put("List.font", userFont);
-				uid.put("PopupMenu.font", userFont);
-				uid.put("ToolTip.font", userFont);
-				uid.put("Separator.font", userFont);
-				uid.put("RadioButtonMenuItem.font", userFont);
-				uid.put("RadioButton.font", userFont);
-				uid.put("ToolBar.font", userFont);
-				uid.put("ScrollPane.font", userFont);
-				uid.put("CheckBoxMenuItem.font", userFont);
-				uid.put("Viewport.font", userFont);
-				uid.put("TextField.font", userFont);
-				uid.put("SplitPane.font", userFont);
-				uid.put("MenuItem.font", userFont);
-				uid.put("OptionPane.font", userFont);
-				uid.put("ArrowButton.font", userFont);
-				uid.put("Label.font", userFont);
-				uid.put("ProgressBar.font", userFont);
-				uid.put("ScrollBar.font", userFont);
-				uid.put("ScrollBarThumb.font", userFont);
-				uid.put("ScrollBarTrack.font", userFont);
-				uid.put("SliderThumb.font", userFont);
-				uid.put("SliderTrack.font", userFont);
-				uid.put("TitledBorder.font", boldFont);
 				
 				uid.put("Table.intercellSpacing", new DimensionUIResource(1, 1));
 				uid.put("Table.showGrid", Boolean.TRUE);


### PR DESCRIPTION
1. changes proposed in this pull request:
 
This PR generalises the font handling across all themes, identical to what is done to Nimbus.
This will hopefully solve the issue with CJK characters handling on different platforms.

@akasolace Would you be able to please check if this fixes the display issues on your system for Zheng Haiguo?
 
2. changelog and release_notes ...

 - [ ] have been updated
 - [x] do not require update


3. [Optional] suggested person to review this PR @akasolace 
