### PR TITLE
Cache jersey icons when they are loaded.

### DIFF
--- a/src/main/java/core/gui/theme/ImageUtilities.java
+++ b/src/main/java/core/gui/theme/ImageUtilities.java
@@ -24,8 +24,6 @@ import java.util.Hashtable;
 
 import javax.swing.*;
 
-import static com.kitfox.svg.app.beans.SVGIcon.INTERP_BILINEAR;
-
 public class ImageUtilities {
 
     /** Hashtable mit Veränderungspfeilgrafiken nach Integer als Key */
@@ -535,9 +533,9 @@ public class ImageUtilities {
 		Color trickotfarbe = null;
 		Icon komplettIcon = null;
 		StringBuilder key = new StringBuilder(20);
-		// Im Cache nachsehen
+
 		key.append("trickot_").append(posid).append("_").append(taktik).append("_").append(trickotnummer);
-		//komplettIcon = ThemeManager.getIcon(key.toString());
+		komplettIcon = ThemeManager.getIcon(key.toString());
 
 		if (komplettIcon == null) {
 			trickotfarbe = getJerseyColorByPosition(posid);
@@ -555,7 +553,7 @@ public class ImageUtilities {
 				icon.setSvgUniverse(new SVGUniverse());
 				icon.setPreferredSize(new Dimension(20, 16));
 				icon.setAutosize(SVGIcon.AUTOSIZE_BESTFIT);
-				icon.setInterpolation(INTERP_BILINEAR);
+				icon.setInterpolation(SVGIcon.INTERP_BILINEAR);
 				icon.setAntiAlias(true);
 
 				icon.setSvgURI(svgURI);
@@ -589,6 +587,7 @@ public class ImageUtilities {
 				}
 
 				komplettIcon = icon;
+				ThemeManager.instance().put(key.toString(), komplettIcon);
 			}
 		}
 


### PR DESCRIPTION
1. changes proposed in this pull request:
 
The new SVG icons for the jerseys are not cached by the `ThemeManager`, which is an oversight, and causes performance issues in Squad and Lineup tabs.   This PR adds the icon to the cache, like for other icons.
 
2. changelog and release_notes ...

 - [ ] have been updated
 - [x] do not require update


3. [Optional] suggested person to review this PR @akasolace 
