### PR TITLE
Fix issue with truncated close button on Nimbus.

### DIFF
--- a/src/main/java/core/gui/comp/tabbedPane/TabCloseIcon.java
+++ b/src/main/java/core/gui/comp/tabbedPane/TabCloseIcon.java
@@ -47,11 +47,11 @@ final class TabCloseIcon implements Icon {
 	}
 
 	/**
-	 * just delegate
+	 * Returns the total width of the close icon, including <code>xOffset</code>.
 	 */
 	@Override
 	public int getIconWidth() {
-		return mIcon.getIconWidth();
+		return mIcon.getIconWidth() + xOffset;
 	}
 
 	/**
@@ -70,5 +70,4 @@ final class TabCloseIcon implements Icon {
 			mTabbedPane.remove(index);
 		}
 	}
-
 }


### PR DESCRIPTION
Following upgrade to Java 11, the close button on the tab is
truncated.  This sets the full width of the icon to the width of the
image plus the offset used to separate the icon from the text.

![Screenshot 2020-06-05 at 19 25 34](https://user-images.githubusercontent.com/114285/83910447-7896be00-a762-11ea-8bea-bc4260cb7690.png)

1. changes proposed in this pull request:

Cf. above. 

2. changelog and release_notes ...

 - [ ] have been updated
 - [x] do not require update


3. [Optional] suggested person to review this PR @akasolace 

