### PR TITLE
Make diverse options panel an ImagePanel for consistency

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,12 +18,12 @@ dependencies {
     implementation 'org.hsqldb:hsqldb:2.4.1'
     implementation 'com.google.code.gson:gson:2.8.6'
     implementation 'com.squareup.okhttp3:okhttp:4.3.1'
-    implementation 'com.github.weisj:darklaf-core:2.2.1'
-    implementation 'com.github.weisj:darklaf-theme:2.2.1'
+    implementation 'com.github.weisj:darklaf-core:2.2.3'
+    implementation 'com.github.weisj:darklaf-theme:2.2.3'
     implementation 'com.formdev:svgSalamander:1.1.2.1'
-    compile 'org.javatuples:javatuples:1.2'
-    compile group: 'org.apache.commons', name: 'commons-text', version: '1.8'     // https://mvnrepository.com/artifact/org.apache.commons/commons-text
-    compile 'org.jetbrains:annotations:16.0.2'
+    implementation 'org.javatuples:javatuples:1.2'
+    implementation 'org.apache.commons:commons-text:1.8'
+    implementation 'org.jetbrains:annotations:16.0.2'
     testImplementation 'junit:junit:4.12'
 }
 

--- a/src/main/java/core/net/DownloadDialog.java
+++ b/src/main/java/core/net/DownloadDialog.java
@@ -192,15 +192,13 @@ public class DownloadDialog extends JDialog implements ActionListener {
 		m_jchShowSaveDialog.setOpaque(false);
 		m_jchShowSaveDialog.addActionListener(this);
 
-		final JPanel diverseOptionsPanel = new JPanel(new BorderLayout(1,2));
+		final JPanel diverseOptionsPanel = new ImagePanel(new BorderLayout(1,2));
 		diverseOptionsPanel.add(matchArchivePanel, BorderLayout.NORTH);
 		diverseOptionsPanel.add(m_jchShowSaveDialog, BorderLayout.SOUTH);
 
 		oldFixturePanel.add(diverseOptionsPanel, BorderLayout.SOUTH);
 
 		specialDownload.add(oldFixturePanel);
-
-
 
 		specialDownload.setSize(260, 280);
 		specialDownload.setLocation(260, 10);
@@ -231,7 +229,7 @@ public class DownloadDialog extends JDialog implements ActionListener {
 		m_jbAbort.setLocation(380, 300);
 		getContentPane().add(m_jbAbort);
 
-		setSize(530, 360);
+		setSize(530, 380);
 
 		final Dimension size = getToolkit().getScreenSize();
 


### PR DESCRIPTION
These are small tweaks to get a nice appearance with Nimbus on Linux:

![Screenshot from 2020-06-13 18-24-02](https://user-images.githubusercontent.com/114285/84575223-7d332600-ada3-11ea-93e5-cf252232fc26.png)

After changes, this looks like:

![Screenshot from 2020-06-13 18-23-28](https://user-images.githubusercontent.com/114285/84575219-77d5db80-ada3-11ea-98c9-1632a158199d.png)

The PR also updates the version of darklaf to ensure all the recent bugfixes are integrated.

1. changes proposed in this pull request:
 
Cf. above.
 
 
2. changelog and release_notes ...

 - [ ] have been updated
 - [x] do not require update


3. [Optional] suggested person to review this PR @akasolace 
