### PR TITLE
Ensure the HOMainFrame does not call itself whilst still loading.

### DIFF
--- a/src/main/java/core/gui/HOMainFrame.java
+++ b/src/main/java/core/gui/HOMainFrame.java
@@ -60,6 +60,7 @@ import java.util.Calendar;
 import java.util.List;
 import java.util.Locale;
 import java.util.Vector;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import javax.swing.InputMap;
 import javax.swing.JFrame;
@@ -107,6 +108,7 @@ public final class HOMainFrame extends JFrame implements Refreshable, ActionList
 	private final JMenuItem m_jmFullScreenItem = new JMenuItem(HOVerwaltung.instance().getLanguageString("ls.menu.file.fullscreen"));
 	private final JMenuItem m_jmBeendenItem = new JMenuItem(HOVerwaltung.instance().getLanguageString("ls.menu.file.quit"));
 
+	public static AtomicBoolean launching = new AtomicBoolean(false);
 
 	// -----------  Functions
 
@@ -141,6 +143,7 @@ public final class HOMainFrame extends JFrame implements Refreshable, ActionList
 	 * Singleton
 	 */
 	private HOMainFrame() {
+		launching.set(true);
 
 		// Log HO! version
 		HOLogger.instance().info(getClass(),
@@ -191,6 +194,7 @@ public final class HOMainFrame extends JFrame implements Refreshable, ActionList
 		initMenue();
 
 		RefreshManager.instance().doRefresh();
+		launching.set(false);
 	}
 
 	final public static boolean isMac() {

--- a/src/main/java/core/net/MyConnector.java
+++ b/src/main/java/core/net/MyConnector.java
@@ -39,7 +39,7 @@ import java.util.zip.GZIPInputStream;
 import java.util.zip.Inflater;
 import java.util.zip.InflaterInputStream;
 
-import javax.swing.JOptionPane;
+import javax.swing.*;
 
 import org.scribe.builder.ServiceBuilder;
 import org.scribe.model.OAuthRequest;
@@ -683,9 +683,19 @@ public class MyConnector {
 					break;
 				case 401:
 					if (authDialog == null) {
+
+						HOMainFrame mainFrame = null;
+                        // If the main frame is not in the process of loading, use it,
+                        // otherwise use null frame.
+						if (!HOMainFrame.launching.get()) {
+							mainFrame = HOMainFrame.instance();
+						}
+
 						// disable WaitCursor to unblock GUI
-						CursorToolkit.stopWaitCursor(HOMainFrame.instance().getRootPane());
-						authDialog = new OAuthDialog(HOMainFrame.instance(), m_OAService, "");
+						if (mainFrame != null) {
+							CursorToolkit.stopWaitCursor(mainFrame.getRootPane());
+						}
+						authDialog = new OAuthDialog(mainFrame, m_OAService, "");
 					}
 					authDialog.setVisible(true);
 					// A way out for a user unable to authorize for some reason

--- a/src/main/java/core/net/login/OAuthDialog.java
+++ b/src/main/java/core/net/login/OAuthDialog.java
@@ -241,11 +241,12 @@ public class OAuthDialog extends JDialog {
 		this.setSize(400, 500);
 		pack();
 
-		Dimension size = m_clMainFrame.getToolkit().getScreenSize();
-		if (size.width > this.getSize().width) { // open dialog in the middle of
-													// the screen
-			this.setLocation((size.width / 2) - (this.getSize().width / 2),
-					(size.height / 2) - (this.getSize().height / 2));
+		if (m_clMainFrame != null) {
+			Dimension size = m_clMainFrame.getToolkit().getScreenSize();
+			if (size.width > this.getSize().width) { // open dialog in the middle of the screen
+				this.setLocation((size.width / 2) - (this.getSize().width / 2),
+						(size.height / 2) - (this.getSize().height / 2));
+			}
 		}
 	}
 }

--- a/src/main/resources/changelog.md
+++ b/src/main/resources/changelog.md
@@ -7,7 +7,9 @@ If you find a bug, please open an issue on [GitHub](https://github.com/akasolace
 
 - [FIX] substitute player can now occupy more than one bench position #506
 
+## Misc
 
+- [FIX] Avoid potential infinite loop at startup. [#584]
 
 # Changelist HO! 3.0
 

--- a/src/main/resources/release_notes.md
+++ b/src/main/resources/release_notes.md
@@ -13,3 +13,7 @@ Changelist HO! 3.1
 ### Lineup
 
 - [FIX] substitute player can now occupy more than one bench position #506
+
+### Misc
+
+- [FIX] Avoid potential infinite loop at startup. [#584]

--- a/version.properties
+++ b/version.properties
@@ -1,2 +1,2 @@
-#Thu May 07 16:12:13 CEST 2020
-buildNumber=2731
+#Thu Jun 18 22:21:38 IST 2020
+buildNumber=2745


### PR DESCRIPTION
Under certain conditions HOMainFrame constructor ends up calling
`HOMainFrame.instance()` which in turn calls the HOMainFrame
constructor, as the null check of the singleton pattern is still
null (the constructor has not completed yet).

This PR ensures the main frame is not loading before display the OAuth
dialog is created.  If it still is loading, the dialog is created with
a null window, which should only cause the dialog to not be centered.

(This PR is for the 3.x release branch – I will create a separate PR for master tomorrow)

1. changes proposed in this pull request:
 
   - fixes issue #584 (partly)
   
2. changelog and release_notes ...

 - [x] have been updated
 - [ ] do not require update


3. [Optional] suggested person to review this PR @akasolace 
