### PR TITLE
Ensure the HOMainFrame does not call itself whilst still loading.

### DIFF
--- a/src/main/java/core/gui/HOMainFrame.java
+++ b/src/main/java/core/gui/HOMainFrame.java
@@ -2,7 +2,6 @@ package core.gui;
 
 import core.HO;
 import core.db.DBManager;
-import core.db.user.User;
 import core.db.user.UserManager;
 import core.file.hrf.HRFImport;
 import core.gui.comp.panel.ImagePanel;
@@ -52,6 +51,7 @@ import java.text.NumberFormat;
 import java.text.SimpleDateFormat;
 import java.util.*;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import javax.swing.InputMap;
 import javax.swing.JFrame;
@@ -106,6 +106,8 @@ public final class HOMainFrame extends JFrame implements Refreshable, ActionList
 	private final JMenuItem m_jmCheckUpdate = new JMenuItem(HOVerwaltung.instance().getLanguageString("ls.menu.file.update.ho"));
 	private final JMenuItem m_jmChangelog = new JMenuItem(HOVerwaltung.instance().getLanguageString("ls.menu.help.changelog"));
 
+	public static AtomicBoolean launching = new AtomicBoolean(false);
+
 
 	// Components
 	private HOTabbedPane m_jtpTabbedPane;
@@ -127,10 +129,11 @@ public final class HOMainFrame extends JFrame implements Refreshable, ActionList
 	 * Singleton
 	 */
 	private HOMainFrame() {
+		launching.set(true);
 
 		if (OSUtils.isMac()) {
 			System.setProperty("apple.laf.useScreenMenuBar", "true");
-            System.setProperty("apple.awt.showGroupBox", "true");
+			System.setProperty("apple.awt.showGroupBox", "true");
 		}
 
 		// Log HO! version
@@ -165,6 +168,7 @@ public final class HOMainFrame extends JFrame implements Refreshable, ActionList
 		initMenue();
 
 		RefreshManager.instance().doRefresh();
+		launching.set(false);
 	}
 
 	private void setFrameTitle() {

--- a/src/main/java/core/net/MyConnector.java
+++ b/src/main/java/core/net/MyConnector.java
@@ -28,6 +28,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.GregorianCalendar;
@@ -411,7 +412,7 @@ public class MyConnector {
 		}
 		urlBuilder.append("&LastMatchDate=");
 		String dateString = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss").format(date);
-		urlBuilder.append(URLEncoder.encode(dateString, "UTF-8"));
+		urlBuilder.append(URLEncoder.encode(dateString, StandardCharsets.UTF_8));
 		return getCHPPWebFile(urlBuilder.toString());
 	}
 
@@ -524,7 +525,7 @@ public class MyConnector {
 		try {
 			is = getNonCHPPWebFile(url, false);
 			if (is != null) {
-				br = new BufferedReader(new InputStreamReader(is, "UTF-8"));
+				br = new BufferedReader(new InputStreamReader(is, StandardCharsets.UTF_8));
 				VersionInfo ret = new VersionInfo();
 				String line;
 
@@ -665,9 +666,21 @@ public class MyConnector {
 					break;
 				case 401:
 					if (authDialog == null) {
+
+						HOMainFrame mainFrame = null;
+
+						// If the main frame is not in the process of loading, use it,
+						// otherwise use null frame.
+
+						if (!HOMainFrame.launching.get()) {
+							mainFrame = HOMainFrame.instance();
+						}
+
 						// disable WaitCursor to unblock GUI
-						CursorToolkit.stopWaitCursor(HOMainFrame.instance().getRootPane());
-						authDialog = new OAuthDialog(HOMainFrame.instance(), m_OAService, "");
+						if (mainFrame != null) {
+							CursorToolkit.stopWaitCursor(mainFrame.getRootPane());
+						}
+						authDialog = new OAuthDialog(mainFrame, m_OAService, "");
 					}
 					authDialog.setVisible(true);
 					// A way out for a user unable to authorize for some reason
@@ -828,7 +841,7 @@ public class MyConnector {
 		StringBuilder builder = new StringBuilder();
 		if (stream != null) {
 			BufferedReader bufferedreader = new BufferedReader(new InputStreamReader(stream,
-					"UTF-8"));
+					StandardCharsets.UTF_8));
 			String line = bufferedreader.readLine();
 			if (line != null) {
 				builder.append(line);

--- a/src/main/java/core/net/login/OAuthDialog.java
+++ b/src/main/java/core/net/login/OAuthDialog.java
@@ -32,16 +32,16 @@ public class OAuthDialog extends JDialog {
 
 	private static final long serialVersionUID = 1798304851624958795L;
 
-	private HOMainFrame m_clMainFrame;
-	private JButton m_jbOK = new JButton();
-	private JButton m_jbBrowse = new JButton();
-	private JButton m_jbCancel = new JButton();
-	private JTextField m_jtfAuthString = new JTextField();
-	private JTextField m_jtfAuthURL = new JTextField();
+	private final HOMainFrame m_clMainFrame;
+	private final JButton m_jbOK = new JButton();
+	private final JButton m_jbBrowse = new JButton();
+	private final JButton m_jbCancel = new JButton();
+	private final JTextField m_jtfAuthString = new JTextField();
+	private final JTextField m_jtfAuthURL = new JTextField();
 	private String m_sUserURL;
 	private boolean m_bUserCancel = false;
 	private boolean m_bFirstTry = true;
-	private OAuthService m_service;
+	private final OAuthService m_service;
 	private Token m_AccessToken;
 	private Token m_RequestToken;
 	private String scopes = "";
@@ -102,7 +102,7 @@ public class OAuthDialog extends JDialog {
 
 	@Override
 	public void setVisible(boolean b) {
-		if (m_bFirstTry == false) {
+		if (!m_bFirstTry) {
 			JOptionPane.showMessageDialog(null, HOVerwaltung.instance()
 					.getLanguageString("oauth.FailedTry"), HOVerwaltung
 					.instance().getLanguageString("oauth.FailedTryHeader"),
@@ -240,11 +240,12 @@ public class OAuthDialog extends JDialog {
 		this.setSize(400, 500);
 		pack();
 
-		Dimension size = m_clMainFrame.getToolkit().getScreenSize();
-		if (size.width > this.getSize().width) { // open dialog in the middle of
-													// the screen
-			this.setLocation((size.width / 2) - (this.getSize().width / 2),
-					(size.height / 2) - (this.getSize().height / 2));
+		if (m_clMainFrame != null) {
+			Dimension size = m_clMainFrame.getToolkit().getScreenSize();
+			if (size.width > this.getSize().width) { // open dialog in the middle of the screen
+				this.setLocation((size.width / 2) - (this.getSize().width / 2),
+						(size.height / 2) - (this.getSize().height / 2));
+			}
 		}
 	}
 }

--- a/src/main/resources/changelog.md
+++ b/src/main/resources/changelog.md
@@ -53,6 +53,7 @@ If you find a bug, please open an issue on [GitHub](https://github.com/akasolace
 
   - [FEAT] Remove jcalendar dependency.
   - [FIX] ExperienceViewer removed #503 
+  - [FIX] Avoid potential infinite loop at startup. [#584]
 
 ### League
 

--- a/src/main/resources/release_notes.md
+++ b/src/main/resources/release_notes.md
@@ -54,6 +54,7 @@ Changelist HO! 4.0
 
   - [FEAT] Remove jcalendar dependency.
   - [FIX] ExperienceViewer removed #503 
+  - [FIX] Avoid potential infinite loop at startup. [#584]
 
 ### League
 


### PR DESCRIPTION
Under certain conditions HOMainFrame constructor ends up calling
`HOMainFrame.instance()` which in turn calls the HOMainFrame
constructor, as the null check of the singleton pattern is still
null (the constructor has not completed yet).

This PR ensures the main frame is not loading before display the OAuth
dialog is created.  If it still is loading, the dialog is created with
a null window, which should only cause the dialog to not be centered.

1. changes proposed in this pull request:
 
   - fixes issue #584 
   
 
2. changelog and release_notes ...

 - [x] have been updated
 - [ ] do not require update


3. [Optional] suggested person to review this PR @akasolace 
