### PR TITLE
Copy dependencies into build dir.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -169,6 +169,9 @@ ospackage {
     from(jar.outputs.files) {
         into 'lib\\ho'
     }
+    from(configurations.runtime) {
+        into 'lib\\ho'
+    }
     from("${projectDir}\\src\\main\\resources\\sprache") {
         into 'lib\\ho\\sprache'
     }
@@ -181,11 +184,6 @@ ospackage {
 
     from("${projectDir}\\src\\main\\resources\\themes") {
         into 'lib\\ho\\themes'
-    }
-
-    from("${projectDir}\\src\\main\\resources") {
-        include "**/*.jar"
-        into "lib\\ho"
     }
 
     from("${projectDir}\\src\\main\\resources") {

--- a/src/main/resources/changelog.md
+++ b/src/main/resources/changelog.md
@@ -10,10 +10,11 @@ If you find a bug, please open an issue on [GitHub](https://github.com/akasolace
 ## Misc
 
 - [FIX] Avoid potential infinite loop at startup. [#584]
+- [FIX] Fix NoClassDefFoundError in Deb package. [#589]
 
 # Changelist HO! 3.0
 
-## Some numbers: 
+## Some numbers:
   - 90 commits
   - 293 files changed (11,027 additions and 6,341 deletions)
   - 42 issues closed
@@ -28,7 +29,7 @@ If you find a bug, please open an issue on [GitHub](https://github.com/akasolace
   - impact of special events on score for both you and your opponent based on latest lineup information
 
   - new match report mocking HT full report
-  
+
   - full control on which game to download (e.g. exclude HTO integrated games)
 
 
@@ -88,7 +89,7 @@ If you find a bug, please open an issue on [GitHub](https://github.com/akasolace
    - [FIX] Index Out Of Bounds Exception at startup on new DBs #448
    - [FIX] fix multiple display issues about player names (composed name, nicknames)  #451
    - [FIX] removed deprecated training block feature  #486
-   
+
 
 ### League
 

--- a/src/main/resources/release_notes.md
+++ b/src/main/resources/release_notes.md
@@ -17,3 +17,4 @@ Changelist HO! 3.1
 ### Misc
 
 - [FIX] Avoid potential infinite loop at startup. [#584]
+- [FIX] Fix NoClassDefFoundError in Deb package. [#589]


### PR DESCRIPTION
Fixes #589.  Dependencies seem to be retrieved from resources, but
they would need to be copied manually there first.  This commit copies
dependencies into `lib/ho`.

This fix is for 3.x only, as it is expected that install4j handles dependencies will handle dependencies for us in 4.x+.

1. changes proposed in this pull request:
 
   - fixes issue #589 

2. changelog and release_notes ...

 - [x] have been updated
 - [ ] do not require update


3. [Optional] suggested person to review this PR @akasolace 
