### PR TITLE
Set a preferred size to avoid display issues.

### DIFF
--- a/src/main/java/core/option/ReleaseChannelPanel.java
+++ b/src/main/java/core/option/ReleaseChannelPanel.java
@@ -3,16 +3,10 @@ package core.option;
 import core.model.HOVerwaltung;
 import core.gui.comp.panel.ImagePanel;
 
-import java.awt.Insets;
-import java.awt.GridBagLayout;
-import java.awt.GridBagConstraints;
+import java.awt.*;
 import java.awt.event.ItemEvent;
 
-import javax.swing.JLabel;
-import javax.swing.JTextArea;
-import javax.swing.JCheckBox;
-import javax.swing.ButtonGroup;
-import javax.swing.JRadioButton;
+import javax.swing.*;
 import javax.swing.event.ChangeEvent;
 
 /**
@@ -61,6 +55,7 @@ public final class ReleaseChannelPanel extends ImagePanel
 
 	private void initComponents() {
 		setLayout(new GridBagLayout());
+		setBorder(BorderFactory.createEmptyBorder(0, 10, 0, 10));
 
 		GridBagConstraints placement;
 
@@ -100,6 +95,7 @@ public final class ReleaseChannelPanel extends ImagePanel
 		m_jta_Description.setLineWrap(true);
 		m_jta_Description.setWrapStyleWord(true);
 		m_jta_Description.setEditable(false);
+		m_jta_Description.setPreferredSize(new Dimension(430, 200));
 		placement = new GridBagConstraints();
 		placement.insets = new Insets(25, 0, 25, 0);
 		placement.fill = GridBagConstraints.BOTH;


### PR DESCRIPTION
For some reason (which I have no time to look into), when
displaying "Release Channel" panel in options, the text area's width
is being drawn by darklaf with an excessive width, causing display
issues in the panel.

Setting the preferred size on the text area solves the problem.

This PR also adds an empty border on the panel to avoid the help text to be set against the left side.

![Screenshot from 2020-07-28 18-40-54](https://user-images.githubusercontent.com/114285/88702192-e7f5b200-d102-11ea-95cd-41e6b9d74cef.png)

1. changes proposed in this pull request:
 
   - fixes issue #648

2. changelog and release_notes ...

 - [ ] have been updated
 - [x] do not require update


3. [Optional] suggested person to review this PR @akasolace 
