### PR TITLE
Display promotion status messages in red.

### DIFF
--- a/src/main/java/core/gui/theme/HOColorName.java
+++ b/src/main/java/core/gui/theme/HOColorName.java
@@ -199,4 +199,8 @@ public interface HOColorName {
 	String FG_BRUISED = "player.state.bruised";
 	String FG_TWO_YELLOW_CARDS = "player.state.two-yellow-cards";
 	String FG_RED_CARD = "player.state.red-card";
+
+	// Promotion
+	String BG_PROMOTION_INFO = "promotion.info.bg";
+	String FG_PROMOTION_INFO = "promotion.info.fg";
 }

--- a/src/main/java/core/gui/theme/ho/HOClassicSchema.java
+++ b/src/main/java/core/gui/theme/ho/HOClassicSchema.java
@@ -497,6 +497,9 @@ public class HOClassicSchema extends Schema implements HOIconName, HOColorName, 
 		put(HOColorName.FG_INJURED, new Color(200, 0, 0));
 		put(HOColorName.FG_TWO_YELLOW_CARDS, new Color(100, 100, 0));
 		put(HOColorName.FG_RED_CARD, new Color(200, 20, 20));
+
+		// Promotion
+		put(HOColorName.FG_PROMOTION_INFO, new Color(238, 39, 39, 255));
 	}
 
 	public Color getDefaultColor(String key) {

--- a/src/main/java/module/series/SeriesPanel.java
+++ b/src/main/java/module/series/SeriesPanel.java
@@ -180,8 +180,8 @@ public class SeriesPanel extends LazyImagePanel {
 		deleteButton.setBackground(ThemeManager.getColor(HOColorName.BUTTON_BG));
 		toolbarPanel.add(deleteButton);
 
-		promotionInfoPanel.setSize(650, 40);
-		promotionInfoPanel.setLocation(290, 0);
+		promotionInfoPanel.setSize(650, 30);
+		promotionInfoPanel.setLocation(290, 5);
 		toolbarPanel.add(promotionInfoPanel);
 
 		toolbarPanel.setPreferredSize(new Dimension(240, 35));

--- a/src/main/java/module/series/promotion/DataSubmitter.java
+++ b/src/main/java/module/series/promotion/DataSubmitter.java
@@ -1,6 +1,7 @@
 package module.series.promotion;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.function.Function;
 
 public interface DataSubmitter {
@@ -26,9 +27,9 @@ public interface DataSubmitter {
      * Locks a block for processing for league with ID <code>leagueId</code>.
      *
      * @param leagueId ID of the league for which we are locking a block.
-     * @return BlockInfo – Details about the locked block.  Returns <code>null</code> if no block available.
+     * @return Optinal<BlockInfo> – Details about the locked block.  Returns empty optional if no block available.
      */
-    BlockInfo lockBlock(int leagueId);
+    Optional<BlockInfo> lockBlock(int leagueId);
 
     /**
      * Submits the data for a block whose details are held in <code>blockInfo</code> as String representing
@@ -44,7 +45,7 @@ public interface DataSubmitter {
      *
      * @param leagueId League ID of the team.
      * @param teamId Team Id of the team.
-     * @return
+     * @return Optional<String> – Optional containing the status of the team, empty if not found.
      */
-    String getPromotionStatus(int leagueId, int teamId);
+    Optional<String> getPromotionStatus(int leagueId, int teamId);
 }

--- a/src/main/java/module/series/promotion/HttpDataSubmitter.java
+++ b/src/main/java/module/series/promotion/HttpDataSubmitter.java
@@ -13,9 +13,7 @@ import java.io.InputStream;
 import java.net.InetSocketAddress;
 import java.net.Proxy;
 import java.security.KeyStore;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
+import java.util.*;
 import java.util.function.Function;
 
 /**
@@ -139,7 +137,7 @@ public class HttpDataSubmitter implements DataSubmitter {
     }
 
     @Override
-    public BlockInfo lockBlock(int leagueId) {
+    public Optional<BlockInfo> lockBlock(int leagueId) {
         HOLogger.instance().info(HttpDataSubmitter.class, String.format("Lock block for league %s...", leagueId));
 
         try {
@@ -185,13 +183,13 @@ public class HttpDataSubmitter implements DataSubmitter {
                     HOLogger.instance().info(HttpDataSubmitter.class, "Block locked: " + blockInfo.blockId);
 
                     response.close();
-                    return blockInfo;
+                    return Optional.of(blockInfo);
                 } else {
                     BlockInfo blockInfo = new BlockInfo();
                     blockInfo.status = obj.get("HTTP Status Code").getAsInt();
 
                     response.close();
-                    return blockInfo;
+                    return Optional.of(blockInfo);
                 }
             }
 
@@ -202,11 +200,11 @@ public class HttpDataSubmitter implements DataSubmitter {
             );
         }
 
-        return null;
+        return Optional.empty();
     }
 
     @Override
-    public String getPromotionStatus(int leagueId, int teamId) {
+    public Optional<String> getPromotionStatus(int leagueId, int teamId) {
 
         try {
             final OkHttpClient client = initializeHttpsClient();
@@ -224,7 +222,7 @@ public class HttpDataSubmitter implements DataSubmitter {
                 HOLogger.instance().info(HttpDataSubmitter.class, "Status: " + promotionStatus);
 
                 response.close();
-                return promotionStatus;
+                return Optional.of(promotionStatus);
             } else {
                 response.close();
             }
@@ -237,7 +235,7 @@ public class HttpDataSubmitter implements DataSubmitter {
             );
         }
 
-        return null;
+        return Optional.empty();
     }
 
     private OkHttpClient initializeHttpsClient() throws Exception {

--- a/src/main/java/module/series/promotion/PromotionInfoPanel.java
+++ b/src/main/java/module/series/promotion/PromotionInfoPanel.java
@@ -2,6 +2,8 @@ package module.series.promotion;
 
 import core.db.DBManager;
 import core.gui.HOMainFrame;
+import core.gui.comp.panel.ImagePanel;
+import core.gui.theme.HOColorName;
 import core.gui.theme.HOIconName;
 import core.gui.theme.ThemeManager;
 import core.model.HOVerwaltung;
@@ -19,17 +21,17 @@ import java.util.stream.Collectors;
 /**
  * Panel displaying the main details about Promotion / Demotion status.
  */
-public class PromotionInfoPanel extends JPanel {
+public class PromotionInfoPanel extends ImagePanel {
 
     private final LeaguePromotionHandler promotionHandler;
     private final HOVerwaltung verwaltung = HOVerwaltung.instance();
 
     // Force font when loading panel, otherwise chooses a different from default.
-    private final Font defaultFont = new Font("SansSerif", Font.PLAIN, UserParameter.instance().schriftGroesse);
+    private final Font defaultFont = new Font("SansSerif", Font.BOLD, UserParameter.instance().schriftGroesse+1);
+    private final Color fgColor = ThemeManager.getColor(HOColorName.FG_PROMOTION_INFO);
 
     public PromotionInfoPanel(LeaguePromotionHandler promotionHandler) {
         this.promotionHandler = promotionHandler;
-        setOpaque(false);
         setLayout(new BoxLayout(this, BoxLayout.LINE_AXIS));
         setBorder(new EmptyBorder(0, 10, 0, 0));
 
@@ -70,6 +72,7 @@ public class PromotionInfoPanel extends JPanel {
         this.add(downloadLeagueButton);
         final JLabel downloadLabel = new JLabel(verwaltung.getLanguageString("pd_status.download.unavailable.data"));
         downloadLabel.setFont(defaultFont);
+        downloadLabel.setForeground(fgColor);
         this.add(downloadLabel);
 
         downloadLeagueButton.setToolTipText(verwaltung.getLanguageString("pd_status.download.data"));
@@ -98,6 +101,7 @@ public class PromotionInfoPanel extends JPanel {
         this.removeAll();
         JLabel infoLeagueData = new JLabel(createPromotionStatusDisplayString(promotionStatus));
         infoLeagueData.setFont(defaultFont);
+        infoLeagueData.setForeground(fgColor);
         this.add(infoLeagueData);
 
         this.revalidate();
@@ -112,6 +116,7 @@ public class PromotionInfoPanel extends JPanel {
                 "pd_status.download.pending",
                 basics.getLiga()));
         processingLabel.setFont(defaultFont);
+        processingLabel.setForeground(fgColor);
         this.add(processingLabel);
 
         this.revalidate();
@@ -126,7 +131,7 @@ public class PromotionInfoPanel extends JPanel {
 
             teamDetails = leaguePromotionInfo.teams
                     .stream()
-                    .map(teamId -> downloadCountryDetails.getTeamSeries(teamId))
+                    .map(downloadCountryDetails::getTeamSeries)
                     .collect(Collectors.toList());
             leagueDetails = teamDetails
                     .stream()

--- a/src/main/resources/changelog.md
+++ b/src/main/resources/changelog.md
@@ -64,6 +64,8 @@ If you find a bug, please open an issue on [GitHub](https://github.com/akasolace
 
 ### League
 
+  - [FEAT] Make Promotion status more visible. [#521]
+
 
 ## Translations
   - HO! is currently available in xx languages thanks to the work of xx translators. The translation status varies a lot from one language to another. If you can help in a language requiring attention please join in the effort and register on [POeditor](https://poeditor.com/join/project/jCaWGL1JCl):

--- a/src/main/resources/release_notes.md
+++ b/src/main/resources/release_notes.md
@@ -50,7 +50,7 @@ Changelist HO! 4.0
 
 ### Training
 
-  - [FIX] Subskill recalc takes into account training that took place before the first hrf download #512 
+  - [FIX] Subskill recalc takes into account training that took place before the first hrf download #512
   - [FIX] Fix bug of training effect of Walkover matches #623
   - [FEAT] Individual training plans for each player in training preview #587
 
@@ -65,6 +65,7 @@ Changelist HO! 4.0
 
 ### League
 
+  - [FEAT] Make Promotion status more visible. [#521]
 
 ## Translations
   - HO! is currently available in xx languages thanks to the work of xx translators. The translation status varies a lot from one language to another. If you can help in a language requiring attention please join in the effort and register on [POeditor](https://poeditor.com/join/project/jCaWGL1JCl):


### PR DESCRIPTION
Currently the only message displayed is the one below, due to #651 .

(Also use optional for handling potentially null values)

![Screenshot from 2020-08-01 12-59-08](https://user-images.githubusercontent.com/114285/89101393-5e422f00-d3f7-11ea-8cf3-b1797b4eb62a.png)
![Screenshot from 2020-08-01 12-58-30](https://user-images.githubusercontent.com/114285/89101394-5edac580-d3f7-11ea-977b-7230df0dfbbb.png)
![Screenshot from 2020-08-01 12-57-55](https://user-images.githubusercontent.com/114285/89101395-5f735c00-d3f7-11ea-8452-62c9b33105c3.png)
![Screenshot from 2020-08-01 12-56-55](https://user-images.githubusercontent.com/114285/89101397-5f735c00-d3f7-11ea-9548-564f34a80f1c.png)

What do you think @akasolace ? 

1. changes proposed in this pull request:
 
   - fixes issue #521

2. changelog and release_notes ...

 - [x] have been updated
 - [ ] do not require update


3. [Optional] suggested person to review this PR @akasolace 
