### PR TITLE
#539 fix ht season correction

### DIFF
--- a/src/main/java/core/util/HTCalendarFactory.java
+++ b/src/main/java/core/util/HTCalendarFactory.java
@@ -22,8 +22,6 @@ public final class HTCalendarFactory {
      * Creates a HTCalendar to calculate local values for a league,  using the economy date to flip
      * over to the next week.
      *
-     * @param model HO data model
-     *
      * @return a HTCalendar.
      */
     public static HTCalendar createEconomyCalendar() {
@@ -36,18 +34,33 @@ public final class HTCalendarFactory {
     	final HTCalendar calendar = new HTCalendar();
     	calendar.initialize(calMark);
     	calendar.setTime(model.getBasics().getDatum());
-
-    	final int correction = calendar.getHTSeason() - model.getBasics().getSeason();
-
-    	calendar.setSeasonCorrection(correction);
+    	calendar.setSeasonCorrection(getHTSeasonCorrection());
     	return calendar;
     }
 
-    /**
+    private static Integer htSeasonCorrection;
+	private static int getHTSeasonCorrection() {
+		if ( htSeasonCorrection == null){
+			HOModel model = HOVerwaltung.instance().getModel();
+			if (model == null || model.getXtraDaten() == null || model.getXtraDaten().getSeriesMatchDate() == null) {
+				return 0;
+			}
+
+			final Calendar calMark = Calendar.getInstance();
+			calMark.setTimeInMillis(model.getXtraDaten().getSeriesMatchDate().getTime());
+			final HTCalendar calendar = new HTCalendar();
+			calendar.initialize(calMark);
+			calendar.setTime(model.getXtraDaten().getSeriesMatchDate());
+
+			htSeasonCorrection = calendar.getHTSeason() - model.getBasics().getSeason();
+		}
+		return htSeasonCorrection;
+	}
+
+	/**
      * Creates a HTCalendar to calculate local values for a league,  using the economy date to flip
      * over to the next week.
      *
-     * @param model HO data model
      * @param date Date to set the calendar
      *
      * @return a HTCalendar.
@@ -89,7 +102,6 @@ public final class HTCalendarFactory {
      * Creates a HTCalendar to calculate local values for a league,  using the training date to
      * flip over to the next week.
      *
-     * @param model HO data model
      *
      * @return a HTCalendar.
      */
@@ -100,23 +112,17 @@ public final class HTCalendarFactory {
         calMark.setTimeInMillis(model.getXtraDaten().getTrainingDate().getTime());
 
         final HTCalendar calendar = new HTCalendar();
-
         calendar.initialize(calMark);
         calendar.setTime(model.getBasics().getDatum());
+		calendar.setSeasonCorrection(getHTSeasonCorrection());
 
-        final int correction = calendar.getHTSeason()
-            - model.getBasics().getSeason();
-
-        calendar.setSeasonCorrection(correction);
-
-        return calendar;
+		return calendar;
     }
 
     /**
      * Creates a HTCalendar to calculate local values for a league,  using the training date to
      * flip over to the next week.
      *
-     * @param model HO data model
      * @param date Date to set the calendar
      *
      * @return a HTCalendar.
@@ -134,12 +140,8 @@ public final class HTCalendarFactory {
 			cal = HTCalendarFactory.createTrainingCalendar(date);
 		else
 			cal = HTCalendarFactory.createEconomyCalendar(date);
-		if (cal != null)
-			return cal.getHTSeason();
-		else
-			return -1;
+		return cal.getHTSeason();
 	}
-    
 	/**
 	 * Get HT-Season of a given date (using the economy calendar)
 	 *
@@ -173,9 +175,6 @@ public final class HTCalendarFactory {
 			cal = HTCalendarFactory.createTrainingCalendar(date);
 		else
 			cal = HTCalendarFactory.createEconomyCalendar(date);
-		if (cal != null)
-			return cal.getHTWeek();
-		else
-			return -1;
+		return cal.getHTWeek();
 	}
 }

--- a/src/main/java/module/training/EffectDAO.java
+++ b/src/main/java/module/training/EffectDAO.java
@@ -54,7 +54,7 @@ public class EffectDAO {
 
             for (Iterator<Player> iterPlayers = players.iterator(); iterPlayers.hasNext();) {
                 Player player = (Player) iterPlayers.next();
-                OldTrainingManager otm = new OldTrainingManager(player);
+                PastTrainingManager otm = new PastTrainingManager(player);
                 List<ISkillChange> skillups = otm.getTrainedSkillups();
 
                 for (Iterator<ISkillChange> iterSkillups = skillups.iterator(); iterSkillups.hasNext();) {

--- a/src/main/java/module/training/PastTrainingManager.java
+++ b/src/main/java/module/training/PastTrainingManager.java
@@ -18,7 +18,7 @@ import java.util.List;
 /**
  * Class that keeps track of the past skillup for the active user
  */
-public class OldTrainingManager {
+public class PastTrainingManager {
 
 	/** List of all skill up */
 	private List<ISkillChange> allSkillups = new ArrayList<ISkillChange>();
@@ -30,7 +30,7 @@ public class OldTrainingManager {
 	 * 
 	 * @param player
 	 */
-	public OldTrainingManager(Player player) {
+	public PastTrainingManager(Player player) {
 		if (player == null) {
 			return;
 		}

--- a/src/main/java/module/training/ui/AnalyzerPanel.java
+++ b/src/main/java/module/training/ui/AnalyzerPanel.java
@@ -9,7 +9,7 @@ import core.model.HOVerwaltung;
 import core.model.player.ISkillChange;
 import core.model.player.Player;
 import core.util.GUIUtils;
-import module.training.OldTrainingManager;
+import module.training.PastTrainingManager;
 import module.training.PlayerSkillChange;
 import module.training.ui.model.ChangesTableModel;
 import module.training.ui.model.ModelChange;
@@ -223,7 +223,7 @@ public class AnalyzerPanel extends LazyPanel implements ActionListener {
 		Map<Integer, List<PlayerSkillChange>> skillupsByType = new HashMap<Integer, List<PlayerSkillChange>>();
 
 		for (Player player : players) {
-			OldTrainingManager otm = new OldTrainingManager(player);
+			PastTrainingManager otm = new PastTrainingManager(player);
 			List<ISkillChange> skillups = otm.getAllSkillups();
 
 			for (ISkillChange skillup : skillups) {

--- a/src/main/java/module/training/ui/model/TrainingModel.java
+++ b/src/main/java/module/training/ui/model/TrainingModel.java
@@ -7,9 +7,8 @@ import core.model.StaffType;
 import core.model.player.Player;
 import core.training.FutureTrainingManager;
 import core.training.TrainingPerWeek;
-import core.training.TrainingWeekManager;
 import core.training.WeeklyTrainingType;
-import module.training.OldTrainingManager;
+import module.training.PastTrainingManager;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -24,7 +23,7 @@ public class TrainingModel {
 	private StaffMember staffMember = new StaffMember();
 	private  List<StaffMember> staff = new ArrayList<>();
 	private List<TrainingPerWeek> futureTrainings;
-	private OldTrainingManager skillupManager;
+	private PastTrainingManager skillupManager;
 	private FutureTrainingManager futureTrainingManager;
 	private final List<ModelChangeListener> listeners = new ArrayList<>();
 
@@ -80,9 +79,9 @@ public class TrainingModel {
 		}
 	}
 
-	public OldTrainingManager getSkillupManager() {
+	public PastTrainingManager getSkillupManager() {
 		if (this.skillupManager == null) {
-			this.skillupManager = new OldTrainingManager(this.activePlayer);
+			this.skillupManager = new PastTrainingManager(this.activePlayer);
 		}
 		return this.skillupManager;
 	}

--- a/src/main/resources/changelog.md
+++ b/src/main/resources/changelog.md
@@ -53,14 +53,15 @@ If you find a bug, please open an issue on [GitHub](https://github.com/akasolace
 
 ### Training
 
-  - [FIX] Subskill recalc takes into account training that took place before the first hrf download #512
-  - [FIX] Fix bug of training effect of Walkover matches #623
-  - [FEAT] Individual training plans for each player in training preview #587
+  - [FIX] Fix bug of season correction calculation. Training effect table shows wrong seasons in week 16 [#539]
+  - [FIX] Subskill recalc takes into account training that took place before the first hrf download [#512]
+  - [FIX] Fix bug of training effect of Walkover matches [#623]
+  - [FEAT] Individual training plans for each player in training preview [#587]
 
 ### Misc
 
   - [FEAT] Remove jcalendar dependency.
-  - [FIX] ExperienceViewer removed #503
+  - [FIX] ExperienceViewer removed [#503]
   - [FIX] Avoid potential infinite loop at startup. [#584]
   - [FIX] Layout issue in multiple screen setup. [#618]
   - [FEAT] Remove all printing functionality.

--- a/src/main/resources/release_notes.md
+++ b/src/main/resources/release_notes.md
@@ -54,14 +54,15 @@ Changelist HO! 4.0
 
 ### Training
 
-  - [FIX] Subskill recalc takes into account training that took place before the first hrf download #512
-  - [FIX] Fix bug of training effect of Walkover matches #623
-  - [FEAT] Individual training plans for each player in training preview #587
+  - [FIX] Fix bug of season correction calculation. Training effect table shows wrong seasons in week 16 [#539]
+  - [FIX] Subskill recalc takes into account training that took place before the first hrf download [#512]
+  - [FIX] Fix bug of training effect of Walkover matches [#623]
+  - [FEAT] Individual training plans for each player in training preview [#587]
 
 ### Misc
 
   - [FEAT] Remove jcalendar dependency.
-  - [FIX] ExperienceViewer removed #503
+  - [FIX] ExperienceViewer removed [#503]
   - [FIX] Avoid potential infinite loop at startup. [#584]
   - [FIX] Layout issue in multiple screen setup. [#618]
   - [FEAT] Remove all printing functionality.


### PR DESCRIPTION
1. changes proposed in this pull request:
 
   - fixes issue #539  
    
2. changelog and release_notes ...

 - [x] have been updated
 - [ ] do not require update


3. [Optional] suggested person to review this PR @akasolace 


How to verify this pull request:

in week 16 downloads

1. before economy date HO V3 and V4(with this PR) should show HTSeason 75 in training effect table
2. after economy date, but before training date HO 3 shows HTSeason 74; V4(with PR) correctly shows HTSeason 75
3. if i'm wrong with 2.; after training date but before match date HO 3 shows HTSeason 74; V4(with PR) correctly shows HTSeason 75.
4. after Match date both versions will show correctly HTSeason 76