### PR TITLE
Reintroduce rendering of null element in PlayerCBItemRenderer

### DIFF
--- a/src/main/java/core/gui/model/PlayerCBItemRenderer.java
+++ b/src/main/java/core/gui/model/PlayerCBItemRenderer.java
@@ -1,4 +1,7 @@
 package core.gui.model;
+
+import core.gui.comp.entry.ColorLabelEntry;
+import core.gui.comp.renderer.HODefaultTableCellRenderer;
 import javax.swing.*;
 import java.awt.*;
 
@@ -7,6 +10,18 @@ public class PlayerCBItemRenderer implements javax.swing.ListCellRenderer<Spiele
 
     @Override
     public Component getListCellRendererComponent(JList<? extends SpielerCBItem> list, SpielerCBItem value, int index, boolean isSelected, boolean cellHasFocus) {
-        return value.getListCellRendererComponent(list, index, isSelected);
+        if (value != null) {
+            return value.getListCellRendererComponent(list, index, isSelected);
+        } else {
+            javax.swing.JLabel m_jlBlank = new javax.swing.JLabel(" ");
+            m_jlBlank.setOpaque(true);
+            if (isSelected) {
+                m_jlBlank.setBackground(HODefaultTableCellRenderer.SELECTION_BG);
+            } else {
+                m_jlBlank.setBackground(ColorLabelEntry.BG_STANDARD);
+            }
+            return m_jlBlank;
+        }
     }
+
 }


### PR DESCRIPTION
In statistics panel, there could be some null elements in the dropdown list

1. changes proposed in this pull request:
 
   - fixes issue #__  
   
   - if not fixing an existing issue, comments explaining the purpose of the PR should be provided)
 
 
2. changelog and release_notes ...

 - [ ] have been updated
 - [x] do not require update


3. [Optional] suggested person to review this PR @___
