### PR TITLE
Store teams formations in match details.

### DIFF
--- a/src/main/java/core/db/DBUpdater.java
+++ b/src/main/java/core/db/DBUpdater.java
@@ -163,6 +163,11 @@ final class DBUpdater {
 			m_clJDBCAdapter.executeUpdate("ALTER TABLE FINANZEN RENAME TO ECONOMY");
 		}
 
+		if (!columnExistsInTable("HomeFormation", MatchDetailsTable.TABLENAME)) {
+			m_clJDBCAdapter.executeUpdate("ALTER TABLE MATCHDETAILS ADD COLUMN HomeFormation VARCHAR(5) ");
+			m_clJDBCAdapter.executeUpdate("ALTER TABLE MATCHDETAILS ADD COLUMN AwayFormation VARCHAR(5) ");
+		}
+
 		updateDBVersion(dbVersion, version);
 	}
 

--- a/src/main/java/core/db/MatchDetailsTable.java
+++ b/src/main/java/core/db/MatchDetailsTable.java
@@ -5,10 +5,7 @@ import core.model.match.Matchdetails;
 import core.util.HOLogger;
 
 import java.sql.ResultSet;
-import java.sql.SQLException;
 import java.sql.Types;
-import java.util.ArrayList;
-import java.util.Vector;
 
 import static core.db.DbUtil.getNullableInt;
 
@@ -22,7 +19,7 @@ final class MatchDetailsTable extends AbstractTable {
 	
 	@Override
 	protected void initColumns() {
-		columns = new ColumnDescriptor[53];
+		columns = new ColumnDescriptor[55];
 		columns[0]= new ColumnDescriptor("MatchID",Types.INTEGER,false,true);
 		columns[1]= new ColumnDescriptor("ArenaId",Types.INTEGER,false);
 		columns[2]= new ColumnDescriptor("ArenaName",Types.VARCHAR,false,256);
@@ -76,8 +73,10 @@ final class MatchDetailsTable extends AbstractTable {
 		columns[50]= new ColumnDescriptor("GuestGoal2",Types.INTEGER,true);
 		columns[51]= new ColumnDescriptor("GuestGoal3",Types.INTEGER,true);
 		columns[52]= new ColumnDescriptor("GuestGoal4",Types.INTEGER,true);
+		columns[53]= new ColumnDescriptor("HomeFormation", Types.VARCHAR, true, 5);
+		columns[54]= new ColumnDescriptor("AwayFormation", Types.VARCHAR, true, 5);
 	}
-	
+
 	@Override
 	protected String[] getCreateIndexStatement() {
 		return new String[] {
@@ -153,18 +152,19 @@ final class MatchDetailsTable extends AbstractTable {
 						getNullableInt(rs, "GuestGoal3"),
 						getNullableInt(rs, "GuestGoal4")
 				};
-				if ( hasValues(homeGoalsInPart)){
+				if (hasValues(homeGoalsInPart)) {
 					details.setHomeGoalsInPart(homeGoalsInPart);
-				}
-				else {
+				} else {
 					details.setHomeGoalsInPart(null);
 				}
-				if ( hasValues(guestGoalsInPart)){
+				if (hasValues(guestGoalsInPart)){
 					details.setGuestGoalsInPart(guestGoalsInPart);
-				}
-				else {
+				} else {
 					details.setGuestGoalsInPart(null);
 				}
+
+				details.setHomeFormation(rs.getString("HomeFormation"));
+				details.setAwayFormation(rs.getString("AwayFormation"));
 				details.setStatisics();
 			}
 		} catch (Exception e) {
@@ -206,6 +206,7 @@ final class MatchDetailsTable extends AbstractTable {
 						+ "RatingIndirectSetPiecesAtt, RatingIndirectSetPiecesDef, "
 						+ "HomeGoal0, HomeGoal1, HomeGoal2, HomeGoal3, HomeGoal4, "
 						+ "GuestGoal0, GuestGoal1, GuestGoal2, GuestGoal3, GuestGoal4 "
+							+ ", HomeFormation, AwayFormation"
 						+ ") VALUES ("
 						+ details.getMatchID()
 						+ ", "
@@ -312,7 +313,11 @@ final class MatchDetailsTable extends AbstractTable {
 						+ details.getGuestGoalsInPart(MatchEvent.MatchPartId.OVERTIME)
 						+ ", "
 						+ details.getGuestGoalsInPart(MatchEvent.MatchPartId.PENALTY_CONTEST)
-						+ ")";
+							+ ", '"
+							+ details.getFormation(true)
+							+ "', '"
+							+ details.getFormation(false)
+						+ "')";
 
 				adapter.executeUpdate(sql);
 

--- a/src/main/java/core/file/xml/ConvertXml2Hrf.java
+++ b/src/main/java/core/file/xml/ConvertXml2Hrf.java
@@ -195,19 +195,19 @@ public class ConvertXml2Hrf {
 		// Team ermitteln, für Ratings der Player wichtig
 		if (matchLineup != null) {
 			Matchdetails md = XMLMatchdetailsParser
-					.parseMachtdetailsFromString(
+					.parseMatchdetailsFromString(
 							mc.getMatchdetails(matchLineup.getMatchID(),
 									matchLineup.getMatchTyp()), null);
 
 			if (matchLineup.getHeimId() == Integer.parseInt(teamdetailsDataMap
 					.get("TeamID").toString())) {
-				matchLineupTeam = (MatchLineupTeam) matchLineup.getHeim();
+				matchLineupTeam = matchLineup.getHeim();
 				if (md != null) {
 					lastAttitude = md.getHomeEinstellung();
 					lastTactic = md.getHomeTacticType();
 				}
 			} else {
-				matchLineupTeam = (MatchLineupTeam) matchLineup.getGast();
+				matchLineupTeam = matchLineup.getGast();
 				if (md != null) {
 					lastAttitude = md.getGuestEinstellung();
 					lastTactic = md.getGuestTacticType();

--- a/src/main/java/core/file/xml/XMLManager.java
+++ b/src/main/java/core/file/xml/XMLManager.java
@@ -48,7 +48,7 @@ public class XMLManager  {
      */
     public static String getFirstChildNodeValue(Element ele) {
         try {
-            if (ele.getFirstChild() != null) {
+            if (ele != null && ele.getFirstChild() != null) {
                 return ele.getFirstChild().getNodeValue();
             }
         } catch (Exception e) {

--- a/src/main/java/core/file/xml/XMLMatchdetailsParser.java
+++ b/src/main/java/core/file/xml/XMLMatchdetailsParser.java
@@ -23,7 +23,7 @@ public class XMLMatchdetailsParser {
     private XMLMatchdetailsParser() {
     }
 
-    public static Matchdetails parseMachtdetailsFromString(String input, MatchLineup matchLineup) {
+    public static Matchdetails parseMatchdetailsFromString(String input, MatchLineup matchLineup) {
         return createMatchdetails(XMLManager.parseString(input), matchLineup);
     }
 
@@ -515,7 +515,9 @@ public class XMLMatchdetailsParser {
             	ele = (Element) root.getElementsByTagName("ArenaID").item(0);
             	md.setArenaID(Integer.parseInt(ele.getFirstChild().getNodeValue()));
             	ele = (Element) root.getElementsByTagName("ArenaName").item(0);
-            	md.setArenaName(ele.getFirstChild().getNodeValue());
+            	if (ele.getFirstChild() != null) {
+					md.setArenaName(ele.getFirstChild().getNodeValue());
+				}
             } catch (Exception e){
             	// This fails at tournament matches - ignore
             }
@@ -599,7 +601,11 @@ public class XMLMatchdetailsParser {
             root = (Element) root.getElementsByTagName("Match").item(0);
             root = (Element) root.getElementsByTagName("AwayTeam").item(0);
 
-            //Data
+            NodeList formation = root.getElementsByTagName("Formation");
+            if (formation.getLength() > 0) {
+            	md.setAwayFormation(formation.item(0).getTextContent());
+			}
+
             ele = (Element) root.getElementsByTagName("AwayTeamID").item(0);
 			if ( ele != null ) md.setGastId(Integer.parseInt(ele.getFirstChild().getNodeValue()));
             ele = (Element) root.getElementsByTagName("AwayTeamName").item(0);
@@ -630,13 +636,13 @@ public class XMLMatchdetailsParser {
 			ele = (Element) root.getElementsByTagName("RatingIndirectSetPiecesDef").item(0);
 			if ( ele != null ) md.setRatingIndirectSetPiecesDef(Integer.parseInt(ele.getFirstChild().getNodeValue()));
 
-			try {
-                ele = (Element) root.getElementsByTagName("TeamAttitude").item(0);
-                md.setGuestEinstellung(Integer.parseInt(ele.getFirstChild().getNodeValue()));
-            } catch (Exception e) {
-                //nicht tragisch da Attrib nur bei eigenem Team vorhanden wäre
-                md.setGuestEinstellung(Matchdetails.EINSTELLUNG_UNBEKANNT);
-            }
+			NodeList teamAttitude = root.getElementsByTagName("TeamAttitude");
+			if (teamAttitude.getLength() > 0) {
+				ele = (Element) teamAttitude.item(0);
+				md.setHomeEinstellung(Integer.parseInt(ele.getFirstChild().getNodeValue()));
+			} else {
+				md.setHomeEinstellung(Matchdetails.EINSTELLUNG_UNBEKANNT);
+			}
         } catch (Exception e) {
             HOLogger.instance().log(XMLMatchdetailsParser.class, e);
             md = null;
@@ -654,6 +660,11 @@ public class XMLMatchdetailsParser {
             root = (Element) root.getElementsByTagName("HomeTeam").item(0);
 
             //Data
+			NodeList formation = root.getElementsByTagName("Formation");
+			if (formation.getLength() > 0) {
+				md.setHomeFormation(formation.item(0).getTextContent());
+			}
+
             ele = (Element) root.getElementsByTagName("HomeTeamID").item(0);
 			if ( ele != null ) md.setHeimId(Integer.parseInt(ele.getFirstChild().getNodeValue()));
             ele = (Element) root.getElementsByTagName("HomeTeamName").item(0);
@@ -684,13 +695,14 @@ public class XMLMatchdetailsParser {
 			ele = (Element) root.getElementsByTagName("RatingIndirectSetPiecesDef").item(0);
 			if ( ele != null ) md.setRatingIndirectSetPiecesDef(Integer.parseInt(ele.getFirstChild().getNodeValue()));
 
-			try {
-                ele = (Element) root.getElementsByTagName("TeamAttitude").item(0);
-                md.setHomeEinstellung(Integer.parseInt(ele.getFirstChild().getNodeValue()));
-            } catch (Exception e) {
-                //nicht tragisch da Attrib nur bei eigenem Team vorhanden wäre, als Unbekannt markieren
-                md.setHomeEinstellung(Matchdetails.EINSTELLUNG_UNBEKANNT);
-            }
+			NodeList teamAttitude = root.getElementsByTagName("TeamAttitude");
+			if (teamAttitude.getLength() > 0) {
+				ele = (Element) teamAttitude.item(0);
+				md.setHomeEinstellung(Integer.parseInt(ele.getFirstChild().getNodeValue()));
+			} else {
+				md.setHomeEinstellung(Matchdetails.EINSTELLUNG_UNBEKANNT);
+			}
+
         } catch (Exception e) {
             HOLogger.instance().log(XMLMatchdetailsParser.class, e);
         }

--- a/src/main/java/core/file/xml/XMLTeamDetailsParser.java
+++ b/src/main/java/core/file/xml/XMLTeamDetailsParser.java
@@ -86,11 +86,15 @@ public class XMLTeamDetailsParser {
 			hash.put("Loginname", (XMLManager.getFirstChildNodeValue(ele)));
 			ele = (Element) root.getElementsByTagName("LastLoginDate").item(0);
 			hash.put("LastLoginDate", (XMLManager.getFirstChildNodeValue(ele)));
-			ele = (Element) root.getElementsByTagName("SupporterTier").item(0);
-			String supportValue = XMLManager.getFirstChildNodeValue(ele);
+
 			String supportStatus = "False";
-			if (supportValue.trim().length() > 0) {
-				supportStatus = "True";
+			NodeList supporterTier = root.getElementsByTagName("SupporterTier");
+			if (supporterTier.getLength() > 0) {
+				ele = (Element) supporterTier.item(0);
+				String supportValue = XMLManager.getFirstChildNodeValue(ele);
+				if (supportValue.trim().length() > 0) {
+					supportStatus = "True";
+				}
 			}
 			hash.put("HasSupporter", supportStatus);
 

--- a/src/main/java/core/file/xml/xmlPlayersParser.java
+++ b/src/main/java/core/file/xml/xmlPlayersParser.java
@@ -142,14 +142,14 @@ public class xmlPlayersParser {
                 ele = (Element) root.getElementsByTagName("SetPiecesSkill").item(0);
                 hash.put("SetPiecesSkill", (XMLManager.getFirstChildNodeValue(ele)));
 
-                //Trainer
-                try {
-                    Element tmp_Trainer = (Element) root.getElementsByTagName("TrainerData").item(0);
+                // Coach
+                NodeList trainerData = root.getElementsByTagName("TrainerData");
+                if (trainerData.getLength() > 0) {
+                    Element tmp_Trainer = (Element) trainerData.item(0);
                     ele = (Element) tmp_Trainer.getElementsByTagName("TrainerType").item(0);
                     hash.put("TrainerType", (XMLManager.getFirstChildNodeValue(ele)));
                     ele = (Element) tmp_Trainer.getElementsByTagName("TrainerSkill").item(0);
                     hash.put("TrainerSkill", (XMLManager.getFirstChildNodeValue(ele)));
-                } catch (Exception ep) {
                 }
 
                 //LastMatch #461

--- a/src/main/java/core/model/match/Matchdetails.java
+++ b/src/main/java/core/model/match/Matchdetails.java
@@ -10,13 +10,11 @@ import core.db.DBManager;
 import core.model.HOVerwaltung;
 import core.net.OnlineWorker;
 import core.util.HOLogger;
-import module.teamAnalyzer.vo.Match;
 
 import java.sql.Timestamp;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import java.util.Vector;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -114,6 +112,9 @@ public class Matchdetails implements core.model.match.IMatchDetails {
      */
     private Integer[] homeGoalsInParts;
     private Integer[] guestGoalsInParts;
+
+    private String homeFormation;
+    private String awayFormation;
 
     public String getResultInPart(MatchEvent.MatchPartId part){
         if ( homeGoalsInParts != null){
@@ -281,21 +282,6 @@ public class Matchdetails implements core.model.match.IMatchDetails {
                 homeGoalsInParts[0] = 5;
             }
         }
-        /*/ check
-        int sumHomeGoals=0;
-        for ( var i : homeGoalsInParts){
-            sumHomeGoals += i;
-        }
-        if ( sumHomeGoals != this.m_iHomeGoals)
-            throw new Exception("error in InitGoalsInParts");
-        int sumGuestGoals=0;
-        for ( var i : guestGoalsInParts){
-            sumGuestGoals += i;
-        }
-        if ( sumGuestGoals != this.m_iGuestGoals)
-            throw new Exception("error in InitGoalsInParts");
-
-         */
     }
 
     public void setHomeGoalsInPart(Integer[] homeGoalsInPart) {
@@ -533,13 +519,15 @@ public class Matchdetails implements core.model.match.IMatchDetails {
      * @return The formation type 4-4-2 or 5-3-2 etc
      */
     public final String getFormation(boolean home) {
-        try {
-            final Pattern p = Pattern.compile(".-.-.");
-            final Matcher m = p.matcher(m_sMatchreport);
-            return m.group();
-        } catch (RuntimeException e) {
-            return "";
-        }
+        return home ? homeFormation : awayFormation;
+    }
+
+    public void setHomeFormation(String homeFormation) {
+        this.homeFormation = homeFormation;
+    }
+
+    public void setAwayFormation(String awayFormation) {
+        this.awayFormation = awayFormation;
     }
 
     /**

--- a/src/main/java/core/net/OnlineWorker.java
+++ b/src/main/java/core/net/OnlineWorker.java
@@ -784,7 +784,7 @@ public class OnlineWorker {
 				return null;
 			}
 			showWaitInformation(20);
-			details = XMLMatchdetailsParser.parseMachtdetailsFromString(matchDetails, lineup);
+			details = XMLMatchdetailsParser.parseMatchdetailsFromString(matchDetails, lineup);
 			showWaitInformation(40);
 			if (details == null) {
 				HOLogger.instance().warning(OnlineWorker.class,

--- a/src/main/java/core/training/TrainingWeekManager.java
+++ b/src/main/java/core/training/TrainingWeekManager.java
@@ -340,8 +340,9 @@ public class TrainingWeekManager {
         int actualWeek = bas.getSpieltag();
         int trainNumber = input.size();
         try {
-            // We are between the training and the match date, and should increase the week by 1. 
-            if (hom.getXtraDaten().getTrainingDate().after(hom.getXtraDaten().getSeriesMatchDate())) {
+            // We are between the training and the match date, and should increase the week by 1.
+            if (hom.getXtraDaten().getTrainingDate() != null &&
+					hom.getXtraDaten().getTrainingDate().after(hom.getXtraDaten().getSeriesMatchDate())) {
                 actualWeek++;
                 if (actualWeek == 17) {
                     actualWeek = 1;

--- a/src/main/java/core/util/HelperWrapper.java
+++ b/src/main/java/core/util/HelperWrapper.java
@@ -155,7 +155,7 @@ public class HelperWrapper {
     public boolean isUserMatch(String matchID, MatchType matchType) {
     	try {
           String input = MyConnector.instance().getMatchdetails(Integer.parseInt(matchID), matchType);
-          Matchdetails mdetails = XMLMatchdetailsParser.parseMachtdetailsFromString(input, null);
+          Matchdetails mdetails = XMLMatchdetailsParser.parseMatchdetailsFromString(input, null);
           int teamID = HOVerwaltung.instance().getModel().getBasics().getTeamId();
           return ((mdetails.getHeimId() == teamID) || (mdetails.getGastId() == teamID));
       } catch (Exception e) {

--- a/src/main/java/module/lineup/AustellungSpielerTable.java
+++ b/src/main/java/module/lineup/AustellungSpielerTable.java
@@ -46,48 +46,7 @@ public final class AustellungSpielerTable extends JTable implements core.gui.Ref
 		setSelectionBackground(HODefaultTableCellRenderer.SELECTION_BG);
 		setBackground(ColorLabelEntry.BG_STANDARD);
 		RefreshManager.instance().registerRefreshable(this);
-		addMouseListener(new MouseAdapter() {
-			@Override
-			public void mouseReleased(MouseEvent e) {
-				int rowindex = getSelectedRow();
-				if (rowindex >= 0){
-					int colAUTO_LINEUP_ID = tableModel.getPositionInArray(UserColumnFactory.AUTO_LINEUP);
-
-					// Last match column
-					int viewColumn = columnAtPoint(e.getPoint());
-					int column = columnModel.getColumn(viewColumn).getModelIndex();
-					String columnName = tableSorter.getColumnName(viewColumn);
-					String lastMatchRating = (HOVerwaltung.instance().getLanguageString("LastMatchRating"));
-
-					Player selectedPlayer = tableSorter.getSpieler(rowindex);
-					if(selectedPlayer != null){
-						if(columnName.equalsIgnoreCase(lastMatchRating)){
-							if(e.isShiftDown()){
-								int matchId = selectedPlayer.getLastMatchId();
-								MatchKurzInfo info = DBManager.instance().getMatchesKurzInfoByMatchID(matchId);
-								HattrickLink.showMatch(matchId + "", info.getMatchTyp().isOfficial());
-							}else if(e.getClickCount()==2) {
-								HOMainFrame.instance().showMatch(selectedPlayer.getLastMatchId());
-							}
-						}
-						else if (column == colAUTO_LINEUP_ID){
-							var result = tableSorter.getValueAt(rowindex, colAUTO_LINEUP_ID);
-							if (result != null) {
-								boolean bSelected = (boolean) result;
-								selectedPlayer.setCanBeSelectedByAssistant(bSelected);
-								if (bSelected) {
-									// this player has been made selectable from the Lineup tab, for consistency we set its position to undefined
-									selectedPlayer.setUserPosFlag(IMatchRoleID.UNKNOWN);
-								} else {
-									selectedPlayer.setUserPosFlag(IMatchRoleID.UNSELECTABLE);
-								}
-								HOMainFrame.instance().getSpielerUebersichtPanel().update();
-							}
-						}
-					}
-				}
-			}
-		});
+		initListeners();
 	}
 
 	@Override
@@ -206,5 +165,48 @@ public final class AustellungSpielerTable extends JTable implements core.gui.Ref
 		tableSorter.initsort();
 	}
 
+	private void initListeners() {
+		addMouseListener(new MouseAdapter() {
+			@Override
+			public void mouseReleased(MouseEvent e) {
+				int rowindex = getSelectedRow();
+				if (rowindex >= 0){
+					int colAUTO_LINEUP_ID = tableModel.getPositionInArray(UserColumnFactory.AUTO_LINEUP);
 
+					// Last match column
+					int viewColumn = columnAtPoint(e.getPoint());
+					int column = columnModel.getColumn(viewColumn).getModelIndex();
+					String columnName = tableSorter.getColumnName(viewColumn);
+					String lastMatchRating = (HOVerwaltung.instance().getLanguageString("LastMatchRating"));
+
+					Player selectedPlayer = tableSorter.getSpieler(rowindex);
+					if(selectedPlayer != null){
+						if(columnName.equalsIgnoreCase(lastMatchRating)){
+							if(e.isShiftDown()){
+								int matchId = selectedPlayer.getLastMatchId();
+								MatchKurzInfo info = DBManager.instance().getMatchesKurzInfoByMatchID(matchId);
+								HattrickLink.showMatch(matchId + "", info.getMatchTyp().isOfficial());
+							}else if(e.getClickCount()==2) {
+								HOMainFrame.instance().showMatch(selectedPlayer.getLastMatchId());
+							}
+						}
+						else if (column == colAUTO_LINEUP_ID){
+							var result = tableSorter.getValueAt(rowindex, colAUTO_LINEUP_ID);
+							if (result != null) {
+								boolean bSelected = (boolean) result;
+								selectedPlayer.setCanBeSelectedByAssistant(bSelected);
+								if (bSelected) {
+									// this player has been made selectable from the Lineup tab, for consistency we set its position to undefined
+									selectedPlayer.setUserPosFlag(IMatchRoleID.UNKNOWN);
+								} else {
+									selectedPlayer.setUserPosFlag(IMatchRoleID.UNSELECTABLE);
+								}
+								HOMainFrame.instance().getSpielerUebersichtPanel().update();
+							}
+						}
+					}
+				}
+			}
+		});
+	}
 }

--- a/src/main/java/module/teamAnalyzer/ui/FilterPanel.java
+++ b/src/main/java/module/teamAnalyzer/ui/FilterPanel.java
@@ -13,8 +13,6 @@ import java.awt.BorderLayout;
 import java.awt.CardLayout;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
-import java.awt.event.ItemEvent;
-import java.awt.event.ItemListener;
 import java.util.Iterator;
 
 import javax.swing.ButtonGroup;
@@ -66,12 +64,10 @@ public class FilterPanel extends JPanel implements ActionListener {
 			TeamAnalyzerPanel.filter.setAutomatic(true);
 			autoPanel.reload();
 			cLayout.show(cards, CARD_AUTOMATIC);
-			return;
 		} else if (radioManual.equals(compo)) {
 			cLayout.show(cards, CARD_MANUAL);
 			TeamAnalyzerPanel.filter.setAutomatic(false);
 			manualPanel.reload();
-			return;
 		}
 	}
 


### PR DESCRIPTION
Also, avoid exceptions in XML parsing for better efficiency.

1. changes proposed in this pull request:

This change stores team formations in the db, as formation was not appearing any more in Team Analysis tab.
 
 
2. changelog and release_notes ...

 - [ ] have been updated
 - [x] do not require update


3. [Optional] suggested person to review this PR @akasolace 
