### PR TITLE
Generalise fix to apply to all scaled icons.

### DIFF
--- a/src/main/java/core/gui/theme/ThemeManager.java
+++ b/src/main/java/core/gui/theme/ThemeManager.java
@@ -1,6 +1,7 @@
 package core.gui.theme;
 
 
+import com.github.weisj.darklaf.icons.DerivableImageIcon;
 import core.db.DBManager;
 import core.db.user.UserManager;
 import core.gui.HOMainFrame;
@@ -95,10 +96,8 @@ public final class ThemeManager {
 		return (Color)obj;
 	}
 
-	public boolean isSet(String key){
-		Boolean tmp = null;
-		if(tmp == null)
-			tmp = (Boolean)classicSchema.get(key);
+	public boolean isSet(String key) {
+		Boolean tmp = (Boolean)classicSchema.get(key);
 		if(tmp == null)
 			tmp = Boolean.FALSE;
 		return tmp;
@@ -117,9 +116,7 @@ public final class ThemeManager {
 	}
 
 	public Object get(String key){
-		Object tmp = null;
-		if(tmp == null)
-			tmp = classicSchema.get(key);
+		Object tmp = classicSchema.get(key);
 
 		if(tmp == null)
 			tmp = UIManager.get(key);
@@ -154,8 +151,15 @@ public final class ThemeManager {
 		return instance().get(key);
 	}
 
-	public static Icon getScaledIcon(String key, int x,int y){
-		return instance().getScaledIconImpl(key, x, y);
+	public static Icon getScaledIcon(String key, int x,int y) {
+		final Icon scaledIcon = instance().getScaledIconImpl(key, x, y);
+
+		// If darklaf, retrieve image, and use as icon.
+		if (scaledIcon instanceof DerivableImageIcon) {
+			return new ImageIcon(((DerivableImageIcon)scaledIcon).getImage());
+		}
+
+		return scaledIcon;
 	}
 
 	public Icon getSmallClubLogo(int teamID){
@@ -166,7 +170,7 @@ public final class ThemeManager {
 		return getClubLogo(teamID, 36);
 	}
 
-	public Icon getClubLogo(int teamID, int width){
+	public Icon getClubLogo(int teamID, int width) {
 		int height = Math.round(width * 260f / 210f);
 		String logoPath = DBManager.instance().getTeamLogoFileName(teamLogoPath, teamID);
 		if (logoPath == null) {
@@ -189,6 +193,7 @@ public final class ThemeManager {
 
 			if (scaledIcon != null) put(scaledKey, scaledIcon);
 		}
+
 		return scaledIcon;
 	}
 
@@ -229,6 +234,4 @@ public final class ThemeManager {
 			im.put(KeyStroke.getKeyStroke(KeyEvent.VK_A, KeyEvent.META_DOWN_MASK), DefaultEditorKit.selectAllAction);
 		}
 	}
-
-
 }

--- a/src/main/java/module/lineup/ratings/MinuteTogglerPanel.java
+++ b/src/main/java/module/lineup/ratings/MinuteTogglerPanel.java
@@ -1,6 +1,5 @@
 package module.lineup.ratings;
 
-import com.github.weisj.darklaf.icons.DerivableImageIcon;
 import core.model.HOVerwaltung;
 import core.gui.theme.HOIconName;
 import core.gui.theme.ThemeManager;
@@ -55,14 +54,6 @@ public final class MinuteTogglerPanel extends JPanel {
 		constraints.weighty = 1;
 		constraints.gridx = 0;
 		constraints.gridy = 0;
-
-		if (whiteGreenClock instanceof DerivableImageIcon) {
-			// If darklaf, retrieve image, and use as icon.
-			avg90Clock.setIcon(new ImageIcon(((DerivableImageIcon)whiteGreenClock).getImage()));
-			avg120Clock.setIcon(new ImageIcon(((DerivableImageIcon)whiteRedClock).getImage()));
-			ratingsGraph.setIcon(new ImageIcon(((DerivableImageIcon)ratingsGraphIcon).getImage()));
-		}
-
 
 		avg90Clock.addMouseListener(new MouseAdapter() {
 			@Override


### PR DESCRIPTION
1. changes proposed in this pull request:
 
This PR generalises the fix for images that do not load until an action is performed in darklak (`DerivableImageIcon` seems to delay load)
 
2. changelog and release_notes ...

 - [ ] have been updated
 - [x] do not require update


3. [Optional] suggested person to review this PR @akasolace 
