### PR TITLE
continuous update of Training table

### DIFF
--- a/src/main/java/core/training/TrainingManager.java
+++ b/src/main/java/core/training/TrainingManager.java
@@ -44,14 +44,20 @@ public class TrainingManager {
 					.map(TrainingPerWeek::getTrainingDate)
 					.max(Instant::compareTo).get();
 			recentTrainings = new TrainingWeekManager(previousTrainingDate.plus(1, ChronoUnit.DAYS), false, true);
-			//TODO: add entries in trainings from recentTrainings => should it be done from here ?
-			//TODO: the function DBManager.instance().saveTrainings() should refresh table in training tab
-			// DBManager.instance().saveTrainings(recentTrainings.getTrainingList(), false);
 
 			// Load next week training
 			nextWeekTraining = TrainingWeekManager.getNextWeekTraining(true);
 		}
     }
+
+
+    public void updateHistoricalTrainings(){
+    	// push trainings that took place since last update into Trainings table
+		recentTrainings.pushPastTrainings2TrainingsTable();
+		
+		// update historical trainings
+		historicalTrainings =  DBManager.instance().getTrainingList();
+	}
 
 
     public static TrainingManager instance() {

--- a/src/main/java/core/training/TrainingWeekManager.java
+++ b/src/main/java/core/training/TrainingWeekManager.java
@@ -275,4 +275,19 @@ public class TrainingWeekManager {
 		DBManager.instance().saveTrainings(m_Trainings, false);
 	}
 
+	/**
+	 * The function push elements of m_Trainings into Training table but not replacing existing entries
+	 *
+	 */
+	public void pushPastTrainings2TrainingsTable(){
+		List<TrainingPerWeek> pastTrainingsSinceLastUpdate = new ArrayList<>();
+		for (var training: m_Trainings){
+			if (training.getTrainingDate().isBefore(cl_NextTrainingDate))
+			{
+				pastTrainingsSinceLastUpdate.add(training);
+			}
+		}
+		DBManager.instance().saveTrainings(pastTrainingsSinceLastUpdate, false);
+	}
+
 }


### PR DESCRIPTION
adds a method updateHistoricalTrainings() in training manager 

1. changes proposed in this pull request:
 
   - ensure training table gets regularly updated by introducing new method updateHistoricalTrainings() in training manager.
   - I suggest this function is called at the end of subskill calculation (to be done)


   
   