### PR TITLE
#903 store training since last download

### DIFF
--- a/src/main/java/core/model/HOModel.java
+++ b/src/main/java/core/model/HOModel.java
@@ -8,6 +8,7 @@ import core.model.misc.Basics;
 import core.model.misc.Economy;
 import core.model.misc.Verein;
 import core.model.player.Player;
+import core.training.TrainingWeekManager;
 import module.youth.YouthPlayer;
 import core.model.series.Liga;
 import core.training.TrainingPerWeek;
@@ -23,6 +24,7 @@ import org.jetbrains.annotations.Nullable;
 import tool.arenasizer.Stadium;
 
 import java.sql.Timestamp;
+import java.time.Duration;
 import java.time.Instant;
 import java.util.*;
 import java.util.stream.Collectors;
@@ -623,5 +625,19 @@ public class HOModel {
                 .filter(i->i.getMatchDate().after(date))
                 .sorted(Comparator.comparing(YouthTraining::getMatchDate))
                 .collect(Collectors.toList());
+    }
+
+    public void storeTrainingsSinceLastDownload() {
+/*        var from = this.getBasics().getActivationDate();
+        if ( o_previousHRF != null){
+            from = o_previousHRF.getDatum();
+        }*/
+        var recentTrainings = TrainingManager.instance().getRecentTrainings();
+        DBManager.instance().saveTrainings(recentTrainings,false);
+
+        /*        if ( from.toInstant().plus(Duration.ofDays(7)).isBefore(this.getXtraDaten().getNextTrainingDate().toInstant()) ){
+            var twm = new TrainingWeekManager(firstTrainingDate, false, false);
+            twm.push2TrainingsTable();
+        }*/
     }
 }

--- a/src/main/java/core/model/HOModel.java
+++ b/src/main/java/core/model/HOModel.java
@@ -628,16 +628,7 @@ public class HOModel {
     }
 
     public void storeTrainingsSinceLastDownload() {
-/*        var from = this.getBasics().getActivationDate();
-        if ( o_previousHRF != null){
-            from = o_previousHRF.getDatum();
-        }*/
         var recentTrainings = TrainingManager.instance().getRecentTrainings();
         DBManager.instance().saveTrainings(recentTrainings,false);
-
-        /*        if ( from.toInstant().plus(Duration.ofDays(7)).isBefore(this.getXtraDaten().getNextTrainingDate().toInstant()) ){
-            var twm = new TrainingWeekManager(firstTrainingDate, false, false);
-            twm.push2TrainingsTable();
-        }*/
     }
 }

--- a/src/main/java/core/model/player/Player.java
+++ b/src/main/java/core/model/player/Player.java
@@ -1834,6 +1834,7 @@ public class Player {
         return PlayerSpeciality.getImpactWeatherEffect(weather, iPlayerSpecialty);
     }
 
+    @Deprecated
     private void incrementSubskills(Player originalPlayer, int trainerlevel, int skill, double points, WeeklyTrainingType wt, TrainingPerPlayer trForPlayer) {
         if (skill < KEEPER || points <= 0)
             return;
@@ -1873,7 +1874,8 @@ public class Player {
      * @param originalPlayer - The player to calculate subskills on
      * @param trainerlevel   - The trainer level
      * @param trainingWeek
-     */
+
+    @Deprecated
     public void calcIncrementalSubskills(Player originalPlayer, int trainerlevel, TrainingPerWeek trainingWeek) {
 
         if (this.hasTrainingBlock()) {
@@ -1893,7 +1895,7 @@ public class Player {
         if (tp == null)
             return;
 
-        /* Time to perform skill drop */
+        // Time to perform skill drop
         if (SkillDrops.instance().isActive()) {
             performSkilldrop(originalPlayer, 1);
         }
@@ -1907,7 +1909,7 @@ public class Player {
         addExperienceSub(trainingForPlayer.getExperienceSub());
 
     }
-
+ */
     /**
      * Training for given player for each skill
      *
@@ -2132,7 +2134,7 @@ public class Player {
      * Used by training, checks for skillup and resets subskill in that case
      *
      * @param old
-     */
+
     public void copySubSkills(Player old) {
         for (int skillType = 0; skillType <= EXPERIENCE; skillType++) {
 
@@ -2147,12 +2149,12 @@ public class Player {
             }
         }
     }
-
+   */
     /**
      * Copy the skills of old player.
      * Used by training
      *
-     * @param old
+     * @param old player to copy from
      */
     public void copySkills(Player old) {
 
@@ -2360,12 +2362,23 @@ public class Player {
 
     }
 
-    private static int[] trainingSkills= { KEEPER, SET_PIECES, DEFENDING, SCORING, WINGER,PASSING,PLAYMAKING };
+    private static int[] trainingSkills= { KEEPER, SET_PIECES, DEFENDING, SCORING, WINGER, PASSING, PLAYMAKING };
 
+    /**
+     * Calculates skill status of the player
+     *
+     * @param previousID Id of the previous download. Previous player status is loaded by this id.
+     * @param trainingWeeks List of training week information
+     */
     public void calcSubskills(int previousID, List<TrainingPerWeek> trainingWeeks) {
         var before = DBManager.instance().getSpieler(previousID).stream()
                 .filter(i -> i.getPlayerID() == this.getPlayerID()).findFirst()
                 .orElse(this.CloneWithoutSubskills());
+
+        // since we don't want to work with temp player objects we calculate skill by skill
+        // whereas experience is calculated within the first skill
+        boolean experienceSubDone = this.getErfahrung() > before.getErfahrung(); // Do not calculate sub on experience skill up
+        var experienceSub = experienceSubDone?0:before.getSubExperience(); // set sub to 0 on skill up
         for (var skill : trainingSkills) {
             var sub = before.getSub4Skill(skill);
 
@@ -2394,13 +2407,20 @@ public class Player {
                                 sub = 0;
                             }
                         }
+
+                        if ( !experienceSubDone){
+                            experienceSub+=trainingPerPlayer.getExperienceSub();
+                            if ( experienceSub > 0.99) experienceSub = 0.99;
+                        }
                     }
                 }
+                experienceSubDone=true;
                 if (valueAfterTraining > valueBeforeTraining) { // Skill up (not yet expected)
                     sub = 0;
                 }
             }
             this.setSubskill4PlayerSkill(skill, sub);
+            this.setSubExperience(experienceSub);
         }
     }
 

--- a/src/main/java/core/net/DownloadDialog.java
+++ b/src/main/java/core/net/DownloadDialog.java
@@ -14,6 +14,8 @@ import core.model.match.MatchKurzInfo;
 import core.model.match.SourceSystem;
 import core.model.player.Player;
 import core.net.login.ProxyDialog;
+import core.training.TrainingManager;
+import core.training.TrainingWeekManager;
 import core.util.HOLogger;
 
 import java.awt.BorderLayout;
@@ -332,6 +334,8 @@ public class DownloadDialog extends JDialog implements ActionListener {
 		}
 
 		DBManager.instance().updateLatestData();
+		model.storeTrainingsSinceLastDownload();
 		model.calcSubskills();
+
 	}
 }

--- a/version.properties
+++ b/version.properties
@@ -1,2 +1,2 @@
-#Mon Feb 22 22:20:17 CET 2021
-buildNumber=3428
+#Tue Feb 23 03:39:45 CET 2021
+buildNumber=3429

--- a/version.properties
+++ b/version.properties
@@ -1,2 +1,2 @@
-#Tue Feb 16 19:47:11 CET 2021
-buildNumber=3423
+#Mon Feb 22 22:20:17 CET 2021
+buildNumber=3428


### PR DESCRIPTION
1. changes proposed in this pull request:
 
  store recent trainings (since last download) in database during download.

calc subskills takes this new downloaded trainings into account.

training panel is NOT refreshed after download - the new training is not displayed
 
2. changelog and release_notes ...

 - [ ] have been updated
 - [x] do not require update


3. [Optional] suggested person to review this PR @akasolace 
