### PR TITLE
uttility function in training manager to support subskill recalculate

### DIFF
--- a/src/main/java/core/db/DBConfigUpdater.java
+++ b/src/main/java/core/db/DBConfigUpdater.java
@@ -63,7 +63,7 @@ final class DBConfigUpdater {
 				ResultSet rs = m_clJDBCAdapter.executeQuery(sql);
 				rs.next();
 				Instant firstTrainingDate = rs.getTimestamp("TRAININGDATE").toInstant();
-				twm = new TrainingWeekManager(firstTrainingDate, false, false);
+				twm = new TrainingWeekManager(firstTrainingDate, false);
 				twm.push2TrainingsTable();
 			} catch (Exception e) {
 				HOLogger.instance().error(DBConfigUpdater.class, "Error when trying to create entries inside TRAINING table");

--- a/src/main/java/core/training/TrainingManager.java
+++ b/src/main/java/core/training/TrainingManager.java
@@ -6,7 +6,6 @@ import core.gui.HOMainFrame;
 import core.model.HOVerwaltung;
 import core.model.player.Player;
 import core.util.HOLogger;
-
 import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
 import java.time.Instant;
@@ -27,7 +26,6 @@ public class TrainingManager implements PropertyChangeListener {
 	private TrainingPerWeek nextWeekTraining;        						// used to determine training bar, include upcoming game   => Created at initilization
     private TrainingWeekManager recentTrainings;     						// trainings that took place (if any null otherwise) since last entry in Training table  => Created at initilization
 	private List<TrainingPerWeek> historicalTrainings;          			// used to populate training history, no match information => Created at initilization
-	private List<TrainingPerWeek> historicalTrainingsInclMatches;           // used for subskill recalculation => Created on request
 
 
 	public static final boolean TRAINING_DEBUG = false;
@@ -52,7 +50,7 @@ public class TrainingManager implements PropertyChangeListener {
 			Instant previousTrainingDate = historicalTrainings.stream()
 					.map(TrainingPerWeek::getTrainingDate)
 					.max(Instant::compareTo).get();
-			recentTrainings = new TrainingWeekManager(previousTrainingDate.plus(1, ChronoUnit.DAYS), false);
+			recentTrainings = new TrainingWeekManager(previousTrainingDate.plus(1, ChronoUnit.DAYS), false, true);
 
 			// Load next week training
 			nextWeekTraining = TrainingWeekManager.getNextWeekTraining();
@@ -61,21 +59,18 @@ public class TrainingManager implements PropertyChangeListener {
 		HOVerwaltung.instance().addPropertyChangeListener(this);
     }
 
-	/**
-	 * compute vector of trainingPerWeeks Vector between 2 dates to be used for subskill recalculation
-	 */
-	public void computeHistoricalTrainingsInclMatches(Instant startDate) {
-		historicalTrainingsInclMatches = new TrainingWeekManager(startDate, false).getTrainingList();
-	}
-
 
 	/**
 	 * compute vector of trainingPerWeeks Vector between 2 dates to be used for subskill recalculation
 	 */
-    public List<TrainingPerWeek> getTrainingsBetweenDates(Instant startDate, Instant endDate){
-    	return historicalTrainingsInclMatches.stream()
+    public List<TrainingPerWeek> getHistoricalTrainingsBetweenDates(Instant startDate, Instant endDate){
+		List<TrainingPerWeek> result = historicalTrainings.stream()
 				.filter(t->t.getTrainingDate().isBefore(endDate) && !startDate.isAfter(t.getTrainingDate()))
 				.collect(Collectors.toList());
+
+		result.forEach(t->t.addMatchesInfo());
+
+    	return result;
 	}
 
     public void updateHistoricalTrainings(){

--- a/src/main/java/core/training/TrainingManager.java
+++ b/src/main/java/core/training/TrainingManager.java
@@ -12,6 +12,7 @@ import java.beans.PropertyChangeListener;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.*;
+import java.util.stream.Collectors;
 import javax.swing.JOptionPane;
 
 /**
@@ -23,12 +24,13 @@ public class TrainingManager implements PropertyChangeListener {
 	// singleton class
 	private static TrainingManager m_clInstance;
 
-	private TrainingPerWeek nextWeekTraining;        // used to determine training bar, include upcoming game   => Created at initilization
-    private TrainingWeekManager recentTrainings;     // trainings that took place (if any null otherwise) since last entry in Training table  => Created at initilization
-	private List<TrainingPerWeek> historicalTrainings;         // used to populate training history, no match information => Created at initilization
+	private TrainingPerWeek nextWeekTraining;        						// used to determine training bar, include upcoming game   => Created at initilization
+    private TrainingWeekManager recentTrainings;     						// trainings that took place (if any null otherwise) since last entry in Training table  => Created at initilization
+	private List<TrainingPerWeek> historicalTrainings;          			// used to populate training history, no match information => Created at initilization
+	private List<TrainingPerWeek> historicalTrainingsInclMatches;           // used for subskill recalculation => Created on request
 
 
-	public static final boolean TRAININGDEBUG = false;
+	public static final boolean TRAINING_DEBUG = false;
 
 
 	public void propertyChange(PropertyChangeEvent evt) {
@@ -50,7 +52,7 @@ public class TrainingManager implements PropertyChangeListener {
 			Instant previousTrainingDate = historicalTrainings.stream()
 					.map(TrainingPerWeek::getTrainingDate)
 					.max(Instant::compareTo).get();
-			recentTrainings = new TrainingWeekManager(previousTrainingDate.plus(1, ChronoUnit.DAYS), false, true);
+			recentTrainings = new TrainingWeekManager(previousTrainingDate.plus(1, ChronoUnit.DAYS), false);
 
 			// Load next week training
 			nextWeekTraining = TrainingWeekManager.getNextWeekTraining();
@@ -59,6 +61,22 @@ public class TrainingManager implements PropertyChangeListener {
 		HOVerwaltung.instance().addPropertyChangeListener(this);
     }
 
+	/**
+	 * compute vector of trainingPerWeeks Vector between 2 dates to be used for subskill recalculation
+	 */
+	public void computeHistoricalTrainingsInclMatches(Instant startDate) {
+		historicalTrainingsInclMatches = new TrainingWeekManager(startDate, false).getTrainingList();
+	}
+
+
+	/**
+	 * compute vector of trainingPerWeeks Vector between 2 dates to be used for subskill recalculation
+	 */
+    public List<TrainingPerWeek> getTrainingsBetweenDates(Instant startDate, Instant endDate){
+    	return historicalTrainingsInclMatches.stream()
+				.filter(t->t.getTrainingDate().isBefore(endDate) && !startDate.isAfter(t.getTrainingDate()))
+				.collect(Collectors.toList());
+	}
 
     public void updateHistoricalTrainings(){
     	// push trainings that took place since last update into Trainings table

--- a/src/main/java/core/training/TrainingPerPlayer.java
+++ b/src/main/java/core/training/TrainingPerPlayer.java
@@ -114,7 +114,7 @@ public class TrainingPerPlayer  {
 	 */
 	private boolean isAfterSkillup (Calendar trainingDate, int skillType) {
 		if (getTimestamp() == null) {
-			if (TrainingManager.TRAININGDEBUG) {
+			if (TrainingManager.TRAINING_DEBUG) {
 				HOLogger.instance().debug(getClass(), 
 						"isAfterSkillup: traindate NULL (" + skillType + ") is always after skillup");
 			}
@@ -122,14 +122,14 @@ public class TrainingPerPlayer  {
 		}
 		Date skillupTime = getLastSkillupDate(skillType, getTimestamp());
 		if (trainingDate.getTimeInMillis() > skillupTime.getTime()) {
-			if (TrainingManager.TRAININGDEBUG) {
+			if (TrainingManager.TRAINING_DEBUG) {
 				HOLogger.instance().debug(getClass(), 
 						"isAfterSkillup: traindate "+trainingDate.getTime().toString() 
 						+ " (" + skillType + ") is after skillup");
 			}
 			return true;	
 		} else {
-			if (TrainingManager.TRAININGDEBUG) {
+			if (TrainingManager.TRAINING_DEBUG) {
 				HOLogger.instance().debug(getClass(), 
 						"isAfterSkillup: traindate "+trainingDate.getTime().toString() 
 						+ " (" + skillType + ") is NOT after skillup");

--- a/src/main/java/core/training/TrainingPerWeek.java
+++ b/src/main/java/core/training/TrainingPerWeek.java
@@ -29,13 +29,14 @@ public class TrainingPerWeek  {
     private MatchKurzInfo[] o_Matches;
     private MatchKurzInfo[] o_NTmatches;
     private DBDataSource o_Source;
+    private boolean o_includeMatches;
 
 
     /**
      *
      * Constructor, matches are not passsed as parameters but are loaded at object creation
      */
-    public TrainingPerWeek(Instant trainingDate, int trainingType, int trainingIntensity, int staminaShare, int trainingAssistantsLevel, int coachLevel, DBDataSource source) {
+    public TrainingPerWeek(Instant trainingDate, int trainingType, int trainingIntensity, int staminaShare, int trainingAssistantsLevel, int coachLevel, DBDataSource source, boolean o_includeMatches) {
         o_TrainingDate = trainingDate;
         o_TrainingType = trainingType;
         o_TrainingIntensity = trainingIntensity;
@@ -44,18 +45,32 @@ public class TrainingPerWeek  {
         o_TrainingAssistantsLevel = trainingAssistantsLevel;
         o_Source = source;
 
-        // Loading matches played the week preceding the training date --------------------------
+        if (o_includeMatches) {
+            // Loading matches played the week preceding the training date --------------------------
+            var _startDate = o_TrainingDate.minus(7, ChronoUnit.DAYS);
+            String _firstMatchDate = DateTimeUtils.InstantToSQLtimeStamp(_startDate);
+            String _lastMatchDate = DateTimeUtils.InstantToSQLtimeStamp(o_TrainingDate.plus(23, ChronoUnit.HOURS));
+            o_Matches = fetchMatches(_firstMatchDate, _lastMatchDate);
+            o_NTmatches = fetchNTMatches(_firstMatchDate, _lastMatchDate);
+        }
+    }
+
+    public TrainingPerWeek(Instant trainingDate, int trainingType, int trainingIntensity, int staminaShare, int trainingAssistantsLevel, int coachLevel, DBDataSource source) {
+        this(trainingDate, trainingType, trainingIntensity, staminaShare, trainingAssistantsLevel, coachLevel, source, false);
+    }
+
+
+    public TrainingPerWeek(Instant trainingDate, int training_type, int training_intensity, int staminaShare, int trainingAssistantsLevel, int coachLevel) {
+        this(trainingDate,training_type,training_intensity,staminaShare,trainingAssistantsLevel,coachLevel, DBDataSource.GUESS);
+    }
+
+    public void addMatchesInfo(){
         var _startDate = o_TrainingDate.minus(7, ChronoUnit.DAYS);
         String _firstMatchDate = DateTimeUtils.InstantToSQLtimeStamp(_startDate);
         String _lastMatchDate = DateTimeUtils.InstantToSQLtimeStamp(o_TrainingDate.plus(23, ChronoUnit.HOURS));
         o_Matches = fetchMatches(_firstMatchDate, _lastMatchDate);
         o_NTmatches = fetchNTMatches(_firstMatchDate, _lastMatchDate);
     }
-
-    public TrainingPerWeek(Instant trainingDate, int training_type, int training_intensity, int staminaShare, int trainingAssistantsLevel, int coachLevel) {
-        this(trainingDate,training_type,training_intensity,staminaShare,trainingAssistantsLevel,coachLevel, DBDataSource.GUESS);
-    }
-
 
     /**
      * function that fetch info of NT match played related to the TrainingPerWeek instance

--- a/src/main/java/core/training/TrainingWeekManager.java
+++ b/src/main/java/core/training/TrainingWeekManager.java
@@ -32,7 +32,7 @@ public class TrainingWeekManager {
 	 * @param includeUpcomingTrainings whether or not the TrainingPerWeek objects will contain upcoming match information
 	 * @param includeMatches whether or not the TrainingPerWeek objects will contain match information
 	 */
-	public TrainingWeekManager(Instant startDate, boolean includeUpcomingTrainings) {
+	public TrainingWeekManager(Instant startDate, boolean includeUpcomingTrainings, boolean includeMatches) {
 		if(HOVerwaltung.instance().getModel() == null) {
 		HOLogger.instance().error(this.getClass(), "model not yet initialized");
 		}
@@ -45,7 +45,11 @@ public class TrainingWeekManager {
 
 		m_StartDate = startDate;
 		m_IncludeUpcomingTrainings = includeUpcomingTrainings;
-		m_Trainings = createTrainingListFromHRF();
+		m_Trainings = createTrainingListFromHRF(includeMatches);
+	}
+
+	public TrainingWeekManager(Instant startDate, boolean includeUpcomingTrainings) {
+		this(startDate, includeUpcomingTrainings, false);
 	}
 
 	public static void reset(){
@@ -98,7 +102,7 @@ public class TrainingWeekManager {
 				coachLevel = rs.getInt("TRAINER");
 				trainingAssistantLevel = rs.getInt("COTRAINER");
 				return new TrainingPerWeek(trainingDate, trainType, trainIntensity, trainStaminaPart, trainingAssistantLevel,
-						coachLevel, DBDataSource.HRF);
+						coachLevel, DBDataSource.HRF, true);
 			}
 		}
 		catch (Exception e) {
@@ -112,7 +116,7 @@ public class TrainingWeekManager {
 	 * Create the list of trainings from DB but excluding 'Trainings' table
 	 *  missing weeks are created by duplicating previous entry
 	 */
-	private List<TrainingPerWeek> createTrainingListFromHRF(){
+	private List<TrainingPerWeek> createTrainingListFromHRF(boolean includeMatches){
 
 		List<TrainingPerWeek>  trainings = new ArrayList<>();
 
@@ -148,12 +152,12 @@ public class TrainingWeekManager {
 				{
 					var previousTraining = trainings.get(trainingsSize - 1);
 					var tpw = new TrainingPerWeek(currDate, previousTraining.getTrainingType(), previousTraining.getTrainingIntensity(), previousTraining.getStaminaShare(), previousTraining.getTrainingAssistantsLevel(), previousTraining.getCoachLevel(),
-							DBDataSource.GUESS);
+							DBDataSource.GUESS, includeMatches);
 					trainings.add(tpw);
 				}
 				else{
 					var tpw = new TrainingPerWeek(currDate, -1, 0, 0, 0, 0,
-							DBDataSource.GUESS);
+							DBDataSource.GUESS, includeMatches);
 					trainings.add(tpw);
 				}
 			}

--- a/src/main/java/core/training/TrainingWeekManager.java
+++ b/src/main/java/core/training/TrainingWeekManager.java
@@ -25,7 +25,6 @@ public class TrainingWeekManager {
     private List<TrainingPerWeek> m_Trainings;
     private Instant m_StartDate;
 	private Boolean m_IncludeUpcomingTrainings;
-	private Boolean m_IncludeMatches;
 
 	/**
 	 * Construct a list of TrainingPerWeek since provided initial training Date
@@ -33,7 +32,7 @@ public class TrainingWeekManager {
 	 * @param includeUpcomingTrainings whether or not the TrainingPerWeek objects will contain upcoming match information
 	 * @param includeMatches whether or not the TrainingPerWeek objects will contain match information
 	 */
-	public TrainingWeekManager(Instant startDate, boolean includeUpcomingTrainings, boolean includeMatches) {
+	public TrainingWeekManager(Instant startDate, boolean includeUpcomingTrainings) {
 		if(HOVerwaltung.instance().getModel() == null) {
 		HOLogger.instance().error(this.getClass(), "model not yet initialized");
 		}
@@ -45,7 +44,6 @@ public class TrainingWeekManager {
 			}
 
 		m_StartDate = startDate;
-		m_IncludeMatches = includeMatches;
 		m_IncludeUpcomingTrainings = includeUpcomingTrainings;
 		m_Trainings = createTrainingListFromHRF();
 	}


### PR DESCRIPTION
introduce methods computeHistoricalTrainingsInclMatches() and getTrainingsBetweenDates() in training manager to ensure minimum impact on existing subskill recalculation methid

 if you have initial date = currentDate - 7 weeks
we need to call once `computeHistoricalTrainingsInclMatches(initial_date)`
then we can do bunch of call as follow `getTrainingsBetweenDates(startDate, endDate)`
startdate will need obviously to be >= initial_date
the idea is to initilize the vector only once
that limit call to the database



