### PR TITLE
Store LastMatch_Type in SPIELER table.

### DIFF
--- a/src/main/java/core/db/DBManager.java
+++ b/src/main/java/core/db/DBManager.java
@@ -1232,15 +1232,21 @@ public class DBManager {
 	 * @param teamId the team id
 	 * @return the match kurz info
 	 */
-	public MatchKurzInfo getLastMatchesKurzInfo(int teamId){
+	public MatchKurzInfo getLastMatchesKurzInfo(int teamId) {
 		return  ((MatchesKurzInfoTable) getTable(MatchesKurzInfoTable.TABLENAME))
 				.getLastMatchesKurzInfo(teamId);
 	}
 
+	public MatchKurzInfo getLastMatchWithMatchId(int matchId) {
+		return ((MatchesKurzInfoTable)getTable(MatchesKurzInfoTable.TABLENAME))
+				.getLastMatchWithMatchId(matchId);
+
+	}
+
 	/**
-	 * Get all matches for the given sql where claus.
+	 * Get all matches for the given sql where clause.
 	 *
-	 * @param where The string containing sql where claus
+	 * @param where The string containing sql where clause
 	 * @return the match kurz info [ ]
 	 */
 	public MatchKurzInfo[] getMatchesKurzInfo(String where) {
@@ -1256,8 +1262,7 @@ public class DBManager {
 	 * @param matchStatus the match status
 	 * @return the match kurz info [ ]
 	 */
-	public MatchKurzInfo[] getMatchesKurzInfo(final int teamId,
-			final int matchStatus) {
+	public MatchKurzInfo[] getMatchesKurzInfo(final int teamId, final int matchStatus) {
 		return ((MatchesKurzInfoTable) getTable(MatchesKurzInfoTable.TABLENAME))
 				.getMatchesKurzInfo(teamId, matchStatus);
 	}
@@ -1297,15 +1302,19 @@ public class DBManager {
 
 
 	/**
-	 * Wichtig: Wenn die Teamid = -1 ist muss der Matchtyp ALLE_SPIELE sein!
+	 * Returns an array of {@link MatchKurzInfo} for the team with ID <code>teamId</code>,
+	 * and of type <code>matchtyp</code>.
 	 *
-	 * @param teamId   Die Teamid oder -1 für alle
-	 * @param matchtyp Welche Matches? Konstanten im SpielePanel!
-	 * @param asc      the asc
-	 * @return the match kurz info [ ]
+	 * Important: if teamId is -1, <code>matchtype</code> must be set to
+	 * <code>MatchesPanel.ALL_MATCHS</code>.
+	 *
+	 * @param teamId   The ID of the team, or -1 for all.
+	 * @param matchtyp Type of match, as defined in {@link module.matches.MatchesPanel}.
+	 * @param asc      Ascending if true, descending otherwise.
+	 *
+	 * @return MatchKurzInfo[] – Array of match info.
 	 */
-	public MatchKurzInfo[] getMatchesKurzInfo(int teamId, int matchtyp,
-			boolean asc) {
+	public MatchKurzInfo[] getMatchesKurzInfo(int teamId, int matchtyp, boolean asc) {
 		return ((MatchesKurzInfoTable) getTable(MatchesKurzInfoTable.TABLENAME))
 				.getMatchesKurzInfo(teamId, matchtyp, asc);
 	}
@@ -1687,7 +1696,7 @@ public class DBManager {
 	/**
 	 * Gets match lineup team.
 	 *
-	 * @param sourceSystem the source system
+	 * @param iMatchType  the type of match
 	 * @param matchID      the match id
 	 * @param teamID       the team id
 	 * @return the match lineup team

--- a/src/main/java/core/db/DBUpdater.java
+++ b/src/main/java/core/db/DBUpdater.java
@@ -323,6 +323,10 @@ final class DBUpdater {
 			HOLogger.instance().debug(getClass(), "Upgrade of DB structure SourceSystem/MatchType is complete ! ");
 		}
 
+        if (!columnExistsInTable("LAST_MATCH_TYPE", "SPIELER")) {
+            m_clJDBCAdapter.executeQuery("ALTER TABLE SPIELER ADD COLUMN LAST_MATCH_TYPE INTEGER ");
+        }
+
 
 		updateDBVersion(dbVersion, 500);
 	}

--- a/src/main/java/core/db/MatchesKurzInfoTable.java
+++ b/src/main/java/core/db/MatchesKurzInfoTable.java
@@ -259,7 +259,7 @@ final class MatchesKurzInfoTable extends AbstractTable {
 		return liste.toArray(new MatchKurzInfo[liste.size()]);
 	}
 
-	public MatchKurzInfo  getLastMatchesKurzInfo(int teamId) {
+	public MatchKurzInfo getLastMatchesKurzInfo(int teamId) {
 		StringBuilder sql = new StringBuilder(100);
 		ResultSet rs = null;
 		try {
@@ -492,6 +492,30 @@ final class MatchesKurzInfoTable extends AbstractTable {
 
 			HOLogger.instance().error(getClass(),
 					"DB.getMatchesKurzInfo Error" + e);
+		}
+
+		return null;
+	}
+
+	public MatchKurzInfo getLastMatchWithMatchId(int matchId) {
+
+		// Find latest match with id = matchId
+		// Here we order by MatchDate, which happens to be string, which is somehow risky,
+		// but it seems to be done in other places.
+		String sql = String.format(
+				"SELECT * FROM %s WHERE MATCHID=%s ORDER BY MATCHDATE DESC LIMIT 1",
+				getTableName(),
+				matchId
+		);
+
+		try {
+			final ResultSet rs = adapter.executeQuery(sql);
+			rs.beforeFirst();
+			if (rs.next()) {
+				return createMatchKurzInfo(rs);
+			}
+		} catch (SQLException e) {
+			HOLogger.instance().error(getClass(), "getLastMatchWithMatchId error: " + e);
 		}
 
 		return null;

--- a/src/main/java/core/file/hrf/HRFFileParser.java
+++ b/src/main/java/core/file/hrf/HRFFileParser.java
@@ -6,7 +6,7 @@ import core.util.IOUtils;
 import java.io.File;
 
 /**
- * Importiert ein HRF-File und stellt die Werte bereit
+ * Imports an HRF file and creates the correponding {@link HOModel} entities.
  */
 public class HRFFileParser {
 
@@ -14,7 +14,7 @@ public class HRFFileParser {
 	}
 
 	/**
-	 * Datei einlesen und parsen
+	 * Reads and parses the {@link File} input.  The format of the file must be HRF.
 	 */
 	public static HOModel parse(File file) {
 
@@ -30,7 +30,6 @@ public class HRFFileParser {
 			HOLogger.instance().log(HRFFileParser.class, e);
 		}
 
-		// Nur im Fehlerfall
 		return null;
 	}
 }

--- a/src/main/java/core/file/hrf/HRFImport.java
+++ b/src/main/java/core/file/hrf/HRFImport.java
@@ -19,7 +19,7 @@ import javax.swing.JFileChooser;
 import javax.swing.JOptionPane;
 
 /**
- * Importiert eine angegebenen HRFDatei
+ * Imports a specified HRF file.
  */
 public class HRFImport {
 
@@ -111,13 +111,6 @@ public class HRFImport {
 
 			HOModel hom = HOVerwaltung.instance().getModel();
 
-//			// Aufstellung in liste als Aktuelle Aufstellungsetzen und als
-//			// Angezeigte Aufstellung
-//			LineupsComparisonHistoryPanel.setHRFAufstellung(hom.getLineup(),
-//					hom.getPreviousLineup());
-//			LineupsComparisonHistoryPanel.setAngezeigteAufstellung(new LineupCBItem(
-//					getLangStr("AktuelleAufstellung"), hom.getLineup()));
-
 			// Refreshen aller Fenster
 			RefreshManager.instance().doReInit();
 		}
@@ -140,8 +133,6 @@ public class HRFImport {
 		filter.addExtension("hrf");
 		filter.setDescription(HOVerwaltung.instance().getLanguageString("filetypedescription.hrf"));
 		fileChooser.setFileFilter(filter);
-
-		Timestamp olderHrf = new Timestamp(System.currentTimeMillis());
 
 		if (fileChooser.showOpenDialog(parent) == JFileChooser.APPROVE_OPTION) {
 			return fileChooser.getSelectedFiles();

--- a/src/main/java/core/file/hrf/HRFStringParser.java
+++ b/src/main/java/core/file/hrf/HRFStringParser.java
@@ -21,7 +21,6 @@ import java.io.BufferedReader;
 import java.io.ByteArrayInputStream;
 import java.io.InputStreamReader;
 import java.sql.Timestamp;
-import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -136,31 +135,15 @@ public class HRFStringParser {
 		}
 		return modelReturn;
 	}
-/*
-	private static Timestamp getDateFromString(String date) {
-		SimpleDateFormat simpleFormat = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss",
-				java.util.Locale.GERMANY);
-		try {
-			// Hattrick
-			return new Timestamp(simpleFormat.parse(date).getTime());
-		} catch (Exception e) {
-			try {
-				// Hattrick
-				simpleFormat = new SimpleDateFormat("yyyy-MM-dd", java.util.Locale.GERMANY);
-				return new Timestamp(simpleFormat.parse(date).getTime());
-			} catch (Exception expc) {
-				HOLogger.instance().log(HRFStringParser.class, e);
-				return new Timestamp(System.currentTimeMillis());
-			}
-		}
-	}
-*/
 
 	/**
-	 * Erzeugt aus dem Vector mit Properties ein HOModel
+	 * Creates a {@link HOModel} instance from list of properties.
+	 *
+	 * @param propertiesList  List of {@link Properties} representing various HT entities.
+	 * @param hrfdate Date of the HRF file.
+	 * @return HOModel – Model built from the properties.
 	 */
-	private static HOModel createHOModel(List<Properties> propertiesList, Timestamp hrfdate)
-			throws Exception {
+	private static HOModel createHOModel(List<Properties> propertiesList, Timestamp hrfdate) throws Exception {
 
 		final HOModel hoModel = new HOModel();
 		int trainerID = -1;
@@ -249,13 +232,13 @@ public class HRFStringParser {
 
 		return hoModel;
 	}
-	
-	
+
+
 	private static List<StaffMember> parseStaff(Properties props) {
-		
+
 		try {
 			ArrayList<StaffMember> list = new ArrayList<>();
-			
+
 			int i = 0;
 			while (props.containsKey("staff" + i + "name")) {
 
@@ -269,10 +252,10 @@ public class HRFStringParser {
 				i++;
 				list.add(member);
 			}
-			
+
 			// because it is handy...
 			Collections.sort(list);
-			
+
 			return list;
 
 		} catch (Exception e) {

--- a/src/main/java/core/file/xml/ConvertXml2Hrf.java
+++ b/src/main/java/core/file/xml/ConvertXml2Hrf.java
@@ -37,8 +37,6 @@ import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 
-import static core.file.xml.XMLManager.xmlValue2Hash;
-
 /**
  * Convert the necessary xml data into a HRF file.
  * 
@@ -54,15 +52,14 @@ public class ConvertXml2Hrf {
 
 	/**
 	 * Create the HRF data and return it in one string.
+	 *
+	 * <p>The HRF file is built using data downloaded from various CHPP endpoints.
 	 * 
 	 * @throws IOException
 	 */
-	public static @Nullable String createHrf()
-			throws IOException {
+	public static @Nullable String createHrf() throws IOException {
 		// init
 		StringBuilder buffer = new StringBuilder();
-
-		// Hashtable's füllen
 		final MyConnector mc = MyConnector.instance();
 		HOMainFrame.instance().setWaitInformation(5);
 
@@ -99,7 +96,10 @@ public class ConvertXml2Hrf {
 				else {
 					// team id is in DB and this is the first time we download youth team information
 					int finalTeamId = teamId;
-					var teaminfo = teamInfoList.stream().filter(x->x.getTeamId()== finalTeamId).findAny().orElse(null);
+					var teaminfo = teamInfoList.stream()
+							.filter(x -> x.getTeamId() == finalTeamId)
+							.findAny()
+							.orElse(null);
 					if ( teaminfo != null){
 						youthTeamId = teaminfo.getYouthTeamId();
 					}
@@ -157,10 +157,10 @@ public class ConvertXml2Hrf {
 		MatchLineup matchLineup = XMLMatchLineupParser.parseMatchLineupFromString(mc.downloadMatchLineup(-1, teamId,
 						MatchType.LEAGUE));
 		HOMainFrame.instance().setWaitInformation(30);
-		List<MyHashtable> playersData = new xmlPlayersParser().parsePlayersFromString(mc.getPlayers(teamId));
+		List<MyHashtable> playersData = new XMLPlayersParser().parsePlayersFromString(mc.getPlayers(teamId));
 		List<MyHashtable> youthplayers=null;
 		if ( youthTeamId != null && youthTeamId > 0 ){
-			youthplayers = new xmlPlayersParser().parseYouthPlayersFromString(mc.downloadYouthPlayers(youthTeamId));
+			youthplayers = new XMLPlayersParser().parseYouthPlayersFromString(mc.downloadYouthPlayers(youthTeamId));
 		}
 		HOMainFrame.instance().setWaitInformation(35);
 		Map<String, String> economyDataMap = XMLEconomyParser.parseEconomyFromString(mc.getEconomy(teamId));
@@ -778,10 +778,10 @@ public class ConvertXml2Hrf {
 	 */
 	private static void createPlayers(MatchLineupTeam matchLineupTeam,
 									  List<MyHashtable> playersData, StringBuilder buffer) {
-		Map<?, ?> ht = null;
+		Map ht = null;
 
 		for (int i = 0; (playersData != null) && (i < playersData.size()); i++) {
-			ht = (Map<?, ?>) playersData.get(i);
+			ht = playersData.get(i);
 
 			buffer.append("[player").append(ht.get("PlayerID").toString())
 					.append(']').append('\n');
@@ -893,6 +893,11 @@ public class ConvertXml2Hrf {
 				buffer.append("LastMatch_Rating=").append('\n');
 				buffer.append("LastMatch_id=0").append('\n');
 			}
+
+			String lastMatchType = (String) ht.getOrDefault("LastMatch_Type", "0");
+			buffer.append("LastMatch_Type=")
+					.append(lastMatchType)
+					.append('\n');
 
 			if ((matchLineupTeam != null)
 					&& (matchLineupTeam.getPlayerByID(Integer.parseInt(ht.get(

--- a/src/main/java/core/file/xml/XMLPlayersParser.java
+++ b/src/main/java/core/file/xml/XMLPlayersParser.java
@@ -3,44 +3,45 @@ package core.file.xml;
 import java.util.List;
 import java.util.Vector;
 
+import core.model.match.MatchKurzInfo;
 import module.youth.YouthPlayer;
 import module.training.Skills;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.w3c.dom.NodeList;
 
+import core.db.DBManager;
+
 import static core.file.xml.XMLManager.xmlAttribute2Hash;
 import static core.file.xml.XMLManager.xmlValue2Hash;
 
 
-public class xmlPlayersParser {
+public class XMLPlayersParser {
     //~ Constructors -------------------------------------------------------------------------------
 
     /**
      * Creates a new instance of xmlPlayersParser
      */
-    public xmlPlayersParser() {
+    public XMLPlayersParser() {
     }
 
     //~ Methods ------------------------------------------------------------------------------------
 
-    /////////////////////////////////////////////////////////////////////////////////    
+    /////////////////////////////////////////////////////////////////////////////////
     //parse public
-    ////////////////////////////////////////////////////////////////////////////////   
+    ////////////////////////////////////////////////////////////////////////////////
     public final Vector<MyHashtable> parsePlayersFromString(String inputStream) {
         Document doc = XMLManager.parseString(inputStream);
         return createListe(doc);
     }
 
-    /////////////////////////////////////////////////////////////////////////////////    
+    /////////////////////////////////////////////////////////////////////////////////
     //Parser Helper private
-    ////////////////////////////////////////////////////////////////////////////////     
+    ////////////////////////////////////////////////////////////////////////////////
 
     /**
      * erzeugt das Team aus dem xml
      */
-
-    //throws Exception
     protected final Vector<MyHashtable> createListe(Document doc) {
         final Vector<MyHashtable> liste = new Vector<>();
 
@@ -162,7 +163,16 @@ public class xmlPlayersParser {
                     ele = (Element) tmp_lm.getElementsByTagName("Rating").item(0);
                     hash.put("LastMatch_Rating", (XMLManager.getFirstChildNodeValue(ele)));
                     ele = (Element) tmp_lm.getElementsByTagName("MatchId").item(0);
-                    hash.put("LastMatch_id", (XMLManager.getFirstChildNodeValue(ele)));
+
+
+                    String lastMatchId = XMLManager.getFirstChildNodeValue(ele);
+                    hash.put("LastMatch_id", lastMatchId);
+
+                    // Retrieve MatchType of last match by its ID.
+                    MatchKurzInfo matchInfo =  DBManager.instance().getLastMatchWithMatchId(Integer.parseInt(lastMatchId));
+                    if (matchInfo != null) {
+                        hash.put("LastMatch_Type", String.valueOf(matchInfo.getMatchType().getId()));
+                    }
 
                     ele = (Element) tmp_lm.getElementsByTagName("PositionCode").item(0);
                     hash.put("LastMatch_PositionCode", (XMLManager.getFirstChildNodeValue(ele)));

--- a/src/main/java/core/model/match/MatchKurzInfo.java
+++ b/src/main/java/core/model/match/MatchKurzInfo.java
@@ -6,7 +6,6 @@ import core.model.cup.CupLevelIndex;
 import core.model.enums.MatchType;
 import core.model.enums.MatchTypeExtended;
 import core.util.HTDatetime;
-import module.specialEvents.Match;
 
 import java.time.ZonedDateTime;
 

--- a/src/main/java/core/model/player/Player.java
+++ b/src/main/java/core/model/player/Player.java
@@ -24,8 +24,8 @@ import java.sql.Timestamp;
 import java.time.Instant;
 import java.util.*;
 
-import static core.constants.player.PlayerSkill.*;
 import static java.lang.Integer.min;
+import static core.constants.player.PlayerSkill.*;
 
 public class Player {
 
@@ -325,6 +325,8 @@ public class Player {
     private String m_lastMatchDate;
     private double m_lastMatchRating=0;
     private int m_lastMatchId=0;
+    private MatchType lastMatchType;
+
 
     /**
      * specifying at what time –in minutes- that player entered the field
@@ -448,6 +450,10 @@ public class Player {
             m_lastMatchRating = 2*Double.parseDouble(properties.getProperty("lastmatch_rating", "0"));
             m_lastMatchId = Integer.parseInt(properties.getProperty("lastmatch_id","0"));
         }
+
+        setLastMatchType(MatchType.getById(
+                Integer.parseInt(properties.getProperty("lastmatch_type", "0"))
+        ));
 
         //Subskills calculation
         //Called when saving the HRF because the necessary data is not available here
@@ -1657,6 +1663,20 @@ public class Player {
      */
     public int getLastMatchId(){
         return m_lastMatchId;
+    }
+
+    /**
+     * Returns the {@link MatchType} of the last match.
+     */
+    public MatchType getLastMatchType() {
+        return lastMatchType;
+    }
+
+    /**
+     * Sets the value of <code>lastMatchType</code> to <code>matchType</code>.
+     */
+    public void setLastMatchType(MatchType matchType) {
+        this.lastMatchType = matchType;
     }
 
     /**

--- a/src/main/java/module/teamAnalyzer/ht/HattrickManager.java
+++ b/src/main/java/module/teamAnalyzer/ht/HattrickManager.java
@@ -3,9 +3,8 @@ package module.teamAnalyzer.ht;
 
 import core.db.DBManager;
 import core.file.xml.XMLManager;
-import core.file.xml.xmlPlayersParser;
+import core.file.xml.XMLPlayersParser;
 import core.model.match.MatchKurzInfo;
-import core.model.match.SourceSystem;
 import core.net.MyConnector;
 import core.net.OnlineWorker;
 import module.teamAnalyzer.manager.PlayerDataManager;
@@ -106,7 +105,7 @@ public class HattrickManager {
         }
 
         List<PlayerInfo> players = new ArrayList<>();
-        var playerInfos = new xmlPlayersParser().parsePlayersFromString(xml);
+        var playerInfos = new XMLPlayersParser().parsePlayersFromString(xml);
         for ( var i : playerInfos ) {
             players.add(new PlayerInfo(i));
         }


### PR DESCRIPTION
1. changes proposed in this pull request:
 
This PR stores `LastMatchType` in the `SPIELER` table to get around an issue with matches ID overlapping.
 
 
2. changelog and release_notes ...

 - [ ] have been updated
 - [x] do not require update


3. [Optional] suggested person to review this PR @akasolace 
