### PR TITLE
Automated release pipeline.

### DIFF
--- a/.github/workflows/release-beta.yml
+++ b/.github/workflows/release-beta.yml
@@ -1,0 +1,39 @@
+name: Automated BETA Release
+
+on:
+  push:
+    tags:
+      - "v*.*.*-beta"
+
+jobs:
+  release-beta:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up JDK 15
+        uses: actions/setup-java@v2
+        with:
+          java-version: '15'
+          distribution: 'adopt'
+      - name: Validate Gradle wrapper
+        uses: gradle/wrapper-validation-action@e6e38bacfdf1a337459f332974bb2327a31aaf4b
+      - name: Download and install install4j
+        run: wget https://download-gcdn.ej-technologies.com/install4j/install4j_linux_8_0_11.deb && sudo dpkg -i install4j_linux_8_0_11.deb
+      - name: Build with Gradle
+        run: ./gradlew build media -x test
+        env:
+          INSTALL4J_HOME: /opt/install4j8
+          INSTALL4J_LICENSE: ${{ secrets.INSTALL4J_LICENSE }}
+          DEV_STAGE: 1
+      - name: Get version
+        id: get_version
+        run: echo "::set-output name=version::$(./gradlew printVersion | grep 'version=' | sed 's/version=//')"
+      - name: Create a Release
+        uses: softprops/action-gh-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+        with:
+          files: |
+            build/artefacts/**
+          name: ${{ steps.get_version.outputs.version }}-BETA
+          prerelease: true

--- a/.github/workflows/release-dev.yml
+++ b/.github/workflows/release-dev.yml
@@ -1,0 +1,38 @@
+name: Automated DEV Release
+
+on:
+  push:
+    tags:
+      - "v*.*.*-dev"
+
+jobs:
+  release-dev:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up JDK 15
+        uses: actions/setup-java@v2
+        with:
+          java-version: '15'
+          distribution: 'adopt'
+      - name: Validate Gradle wrapper
+        uses: gradle/wrapper-validation-action@e6e38bacfdf1a337459f332974bb2327a31aaf4b
+      - name: Download and install install4j
+        run: wget https://download-gcdn.ej-technologies.com/install4j/install4j_linux_8_0_11.deb && sudo dpkg -i install4j_linux_8_0_11.deb
+      - name: Build with Gradle
+        run: ./gradlew build media -x test
+        env:
+          INSTALL4J_HOME: /opt/install4j8
+          INSTALL4J_LICENSE: ${{ secrets.INSTALL4J_LICENSE }}
+      - name: Get version
+        id: get_version
+        run: echo "::set-output name=version::$(./gradlew printVersion | grep 'version=' | sed 's/version=//')"
+      - name: Create a Release
+        uses: softprops/action-gh-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+        with:
+          files: |
+            build/artefacts/**
+          name: ${{ steps.get_version.outputs.version }}-DEV
+          prerelease: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,40 @@
+name: Automated Release
+
+on:
+  push:
+    tags:
+      - "v*.*.*"
+      - "!v*.*.*-dev"
+      - "!v*.*.*-beta"
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up JDK 15
+        uses: actions/setup-java@v2
+        with:
+          java-version: '15'
+          distribution: 'adopt'
+      - name: Validate Gradle wrapper
+        uses: gradle/wrapper-validation-action@e6e38bacfdf1a337459f332974bb2327a31aaf4b
+      - name: Download and install install4j
+        run: wget https://download-gcdn.ej-technologies.com/install4j/install4j_linux_8_0_11.deb && sudo dpkg -i install4j_linux_8_0_11.deb
+      - name: Build with Gradle
+        run: ./gradlew build media -x test
+        env:
+          INSTALL4J_HOME: /opt/install4j8
+          INSTALL4J_LICENSE: ${{ secrets.INSTALL4J_LICENSE }}
+          DEV_STAGE: 2
+      - name: Get version
+        id: get_version
+        run: echo "::set-output name=version::$(./gradlew printVersion | grep 'version=' | sed 's/version=//')"
+      - name: Create a Release
+        uses: softprops/action-gh-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+        with:
+          files: |
+            build/artefacts/**
+          name: ${{ steps.get_version.outputs.version }}

--- a/build.gradle
+++ b/build.gradle
@@ -42,7 +42,7 @@ test {
 // Development_stage (DEV:0  BETA:1  STABLE:2)
 def major = '5'
 def minor = '0'
-def development_stage = '0'
+def development_stage = System.getenv("DEV_STAGE") ?:'0'
 def releaseArtefacts = true
 
 // region configuration ==============================================================================================
@@ -95,6 +95,13 @@ sourceSets {
             srcDirs = ["src/test/resources"]
         }
     }
+}
+
+// Returns the build version numbrt
+// This is required by the Automated build, in this format:
+//      version=<version_number>
+task printVersion() {
+     print "version=${project.version}"
 }
 
 //  configure markdownToHtml --------------------------------
@@ -158,8 +165,9 @@ distributions {
 
 install4j {
     if (install4jHomeDir != null && install4jHomeDir != "") installDir = file(install4jHomeDir)
-    else installDir = file("foo")
+    else installDir = file(System.getenv('INSTALL4J_HOME'))
     disableSigning = true
+    license = System.getenv('INSTALL4J_LICENSE')
 }
 
 // endregion ======================================================================================================================

--- a/version.properties
+++ b/version.properties
@@ -1,2 +1,2 @@
-#Tue Jun 08 18:50:47 CEST 2021
-buildNumber=3651
+#Sat Jul 31 14:18:04 IST 2021
+buildNumber=3671


### PR DESCRIPTION
For the pipeline to kick off, a tag must be created:
- v<major>.<minor>.<patch>-dev for a dev release;
- v<major>.<minor>.<patch>-beta for a beta release;
- v<major>.<minor>.<patch> for a stable release.

It creates an automated release in Github based on a the version of
the Gradle project.  All the artefacts under `build/artefacts/` are
attached to the build.

The build process requires two secrets to be installed in the
repository:

- A github token `RELEASE_TOKEN`, with release write permissions;
- A valid install4j license `INSTALL4J_LICENSE`.

(I don't have permissions to set those Secrets in this project)

1. changes proposed in this pull request:
 
  cf. above.
 
2. changelog and release_notes ...

 - [ ] have been updated
 - [x] do not require update


3. [Optional] suggested person to review this PR @akasolace  @wsbrenk 
