### PR TITLE
Tweak release process to use dev, beta and stable tags.

### DIFF
--- a/.github/workflows/release-beta.yml
+++ b/.github/workflows/release-beta.yml
@@ -4,6 +4,7 @@ on:
   push:
     tags:
       - "v*.*.*-beta"
+      - "beta"
 
 jobs:
   release-beta:
@@ -19,15 +20,25 @@ jobs:
         uses: gradle/wrapper-validation-action@e6e38bacfdf1a337459f332974bb2327a31aaf4b
       - name: Download and install install4j
         run: wget https://download-gcdn.ej-technologies.com/install4j/install4j_linux_8_0_11.deb && sudo dpkg -i install4j_linux_8_0_11.deb
+      - name: Get version
+        id: get_version
+        run: echo "::set-output name=version::$(./gradlew printVersion | grep 'version=' | sed 's/version=//')"
+        env:
+          INSTALL4J_HOME: /opt/install4j8
+          INSTALL4J_LICENSE: ${{ secrets.INSTALL4J_LICENSE }}
       - name: Build with Gradle
         run: ./gradlew build media -x test
         env:
           INSTALL4J_HOME: /opt/install4j8
           INSTALL4J_LICENSE: ${{ secrets.INSTALL4J_LICENSE }}
           DEV_STAGE: 1
-      - name: Get version
-        id: get_version
-        run: echo "::set-output name=version::$(./gradlew printVersion | grep 'version=' | sed 's/version=//')"
+      - name: Delete previous tag and release
+        uses: dev-drprasad/delete-tag-and-release@v0.2.0
+        with:
+          delete_release: true
+          tag_name: beta
+        env:
+          GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN }}
       - name: Create a Release
         uses: softprops/action-gh-release@v1
         env:
@@ -35,5 +46,8 @@ jobs:
         with:
           files: |
             build/artefacts/**
+          target_commitish: master
           name: ${{ steps.get_version.outputs.version }}-BETA
+          tag_name: beta
+          body_path: src/main/resources/release_notes.md
           prerelease: true

--- a/.github/workflows/release-dev.yml
+++ b/.github/workflows/release-dev.yml
@@ -4,6 +4,7 @@ on:
   push:
     tags:
       - "v*.*.*-dev"
+      - "dev"
 
 jobs:
   release-dev:
@@ -19,14 +20,24 @@ jobs:
         uses: gradle/wrapper-validation-action@e6e38bacfdf1a337459f332974bb2327a31aaf4b
       - name: Download and install install4j
         run: wget https://download-gcdn.ej-technologies.com/install4j/install4j_linux_8_0_11.deb && sudo dpkg -i install4j_linux_8_0_11.deb
+      - name: Get version
+        id: get_version
+        run: echo "::set-output name=version::$(./gradlew printVersion | grep 'version=' | sed 's/version=//')"
+        env:
+          INSTALL4J_HOME: /opt/install4j8
+          INSTALL4J_LICENSE: ${{ secrets.INSTALL4J_LICENSE }}
       - name: Build with Gradle
         run: ./gradlew build media -x test
         env:
           INSTALL4J_HOME: /opt/install4j8
           INSTALL4J_LICENSE: ${{ secrets.INSTALL4J_LICENSE }}
-      - name: Get version
-        id: get_version
-        run: echo "::set-output name=version::$(./gradlew printVersion | grep 'version=' | sed 's/version=//')"
+      - name: Delete previous tag and release
+        uses: dev-drprasad/delete-tag-and-release@v0.2.0
+        with:
+          delete_release: true
+          tag_name: dev
+        env:
+          GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN }}
       - name: Create a Release
         uses: softprops/action-gh-release@v1
         env:
@@ -35,4 +46,7 @@ jobs:
           files: |
             build/artefacts/**
           name: ${{ steps.get_version.outputs.version }}-DEV
+          tag_name: dev
+          body_path: src/main/resources/release_notes.md
+          target_commitish: master
           prerelease: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,7 @@ on:
       - "v*.*.*"
       - "!v*.*.*-dev"
       - "!v*.*.*-beta"
+      - "tag_stable"
 
 jobs:
   release:
@@ -21,15 +22,25 @@ jobs:
         uses: gradle/wrapper-validation-action@e6e38bacfdf1a337459f332974bb2327a31aaf4b
       - name: Download and install install4j
         run: wget https://download-gcdn.ej-technologies.com/install4j/install4j_linux_8_0_11.deb && sudo dpkg -i install4j_linux_8_0_11.deb
+      - name: Get version
+        id: get_version
+        run: echo "::set-output name=version::$(./gradlew printVersion | grep 'version=' | sed 's/version=//')"
+        env:
+          INSTALL4J_HOME: /opt/install4j8
+          INSTALL4J_LICENSE: ${{ secrets.INSTALL4J_LICENSE }}
       - name: Build with Gradle
         run: ./gradlew build media -x test
         env:
           INSTALL4J_HOME: /opt/install4j8
           INSTALL4J_LICENSE: ${{ secrets.INSTALL4J_LICENSE }}
           DEV_STAGE: 2
-      - name: Get version
-        id: get_version
-        run: echo "::set-output name=version::$(./gradlew printVersion | grep 'version=' | sed 's/version=//')"
+      - name: Delete previous tag and release
+        uses: dev-drprasad/delete-tag-and-release@v0.2.0
+        with:
+          delete_release: true
+          tag_name: tag_stable
+        env:
+          GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN }}
       - name: Create a Release
         uses: softprops/action-gh-release@v1
         env:
@@ -38,3 +49,5 @@ jobs:
           files: |
             build/artefacts/**
           name: ${{ steps.get_version.outputs.version }}
+          tag_name: tag_stable
+          body_path: src/main/resources/release_notes.md

--- a/build.gradle
+++ b/build.gradle
@@ -97,11 +97,13 @@ sourceSets {
     }
 }
 
-// Returns the build version numbrt
+// Returns the build version number
 // This is required by the Automated build, in this format:
 //      version=<version_number>
-task printVersion() {
-     print "version=${project.version}"
+task printVersion {
+     doFirst {
+          print "version=${project.version}"
+     }
 }
 
 //  configure markdownToHtml --------------------------------
@@ -231,8 +233,8 @@ task media(type: com.install4j.gradle.Install4jTask) {
 
 task preparingBuild(dependsOn: clean) {
     group 'sub tasks'
-    if (releaseArtefacts) {
-        doLast {
+    doLast {
+        if (releaseArtefacts) {
             //     Deleting build project     ---------------------------------------------------------------------
             println("Deleting build and execution files ....")
             project.delete(files("${projectDir}/db"))
@@ -404,8 +406,8 @@ task resetDB {
     group 'tool'
     description 'copy the database from existing install into project'
 
-    try {
-	    doLast {
+    doLast {
+        try {
             println("Resetting DB: copying DB from `${resetDir}` into  ${projectDir}")
             copy {
                 from resetDir
@@ -414,10 +416,9 @@ task resetDB {
             }
 
             println("Resetting DB: done !")
+        } catch (Exception e) {
+            println("Resetting DB: CANNOT copy DB from `${resetDir}` into  ${projectDir}"); return false;
         }
-
-    } catch (java.lang.Exception e) {
-    	println("Resetting DB: CANNOT copy DB from `${resetDir}` into  ${projectDir}"); return false;
     }
 }
 
@@ -431,86 +432,6 @@ markdownToHtml {
     markdownToHtml.hardwraps = true
 }
 
-
-
-task releaseDEVtoGitHub() {
-    def _token = GITHUB_TOKEN  // required token for your personal access with repo permissions
-    doLast {
-        githubRelease {
-            owner = 'akasolace'
-            repo = 'HO'
-            releaseAssets = file("$target_dir").listFiles()
-            token = _token
-            tagName = "dev"
-            releaseName = "dev"
-            targetCommitish = "master"
-            body = "Latest development version aimed at developers"
-            prerelease = true
-            overwrite = true
-        }
-        println "DEVELOPMENT version is being released on GitHub"
-    }
-}
-
-task releaseBETAtoGitHub() {
-    def _token = GITHUB_TOKEN  // required token for your personal access with repo permissions
-    doLast {
-        githubRelease {
-            owner = 'akasolace'
-            repo = 'HO'
-            releaseAssets = file("$target_dir").listFiles()
-            token = _token
-            tagName = "beta"
-            releaseName = "beta"
-            targetCommitish = "master"
-            body = "Latest beta release"
-            prerelease = true
-            overwrite = true
-        }
-        println "BETA version is being released on GitHub"
-    }
-}
-
-task releaseSTABLEtoGitHub() {
-    def _token = GITHUB_TOKEN  // required token for your personal access with repo permissions
-    doLast {
-        githubRelease {
-            owner = 'akasolace'
-            repo = 'HO'
-            releaseAssets = file("$target_dir").listFiles()
-            token = _token
-            tagName = "tag_stable"
-            releaseName = "stable"
-            targetCommitish = "master"
-            body = "Latest stable release"
-            prerelease = true
-            overwrite = true
-        }
-        println "BETA version is being released on GitHub, release XX.XX should still be created manually"
-    }
-}
-
-
-releaseDEVtoGitHub.finalizedBy(tasks.getByName('githubRelease'))
-releaseBETAtoGitHub.finalizedBy(tasks.getByName('githubRelease'))
-releaseSTABLEtoGitHub.finalizedBy(tasks.getByName('githubRelease'))
-releaseBETAtoGitHub.dependsOn releaseDEVtoGitHub
-releaseSTABLEtoGitHub.dependsOn releaseBETAtoGitHub
-
-task releaseToGitHub {
-    group 'ho'
-    if (releaseArtefacts) {
-        if (development_stage == '0') {
-            dependsOn 'releaseDEVtoGitHub'
-        } else if (development_stage == '1') {
-            dependsOn 'releaseBETAtoGitHub'
-        } else {
-            dependsOn 'releaseSTABLEtoGitHub'
-        }
-    }
-}
-
-compileJava.dependsOn preparingBuild
 installDist.dependsOn createLanguageFileList
 poeditorPull.dependsOn markdownToHtml
 markdownToHtml.dependsOn pushmd

--- a/version.properties
+++ b/version.properties
@@ -1,2 +1,2 @@
-#Sat Jul 31 14:18:04 IST 2021
-buildNumber=3671
+#Sat Aug 07 18:08:44 IST 2021
+buildNumber=3700


### PR DESCRIPTION
As the release process is now done using GitHub actions, the dedicated
gradle functions have been removed.  The releases also now include the
release notes in their description.

1. changes proposed in this pull request:
 
  cf. above
 
2. changelog and release_notes ...

 - [ ] have been updated
 - [x] do not require update


3. [Optional] suggested person to review this PR @akasolace 
