### PR TITLE
latest.html release current dev 3723

### DIFF
--- a/docs/latest.html
+++ b/docs/latest.html
@@ -1,2 +1,2 @@
-version=5.0.3650.0
-released=08.06.2021
+version=5.0.3723.0
+released=22.08.2021


### PR DESCRIPTION
1. changes proposed in this pull request:

forward old latest.html to the new update process. 

Updates of the new HO version no longer require latest.html to find new version (they will use the version.properties in the download folders).

HO versions prior to 3723 will use this latest.html to find the new update.
 
 
2. changelog and release_notes ...

 - [ ] have been updated
 - [x] do not require update


3. [Optional] suggested person to review this PR @___
