### PR TITLE
#1130 fix MatchKurzInfo.getMatchType wrong calling of inferMissingMat…

### DIFF
--- a/src/main/java/core/model/match/MatchKurzInfo.java
+++ b/src/main/java/core/model/match/MatchKurzInfo.java
@@ -355,8 +355,7 @@ public class MatchKurzInfo implements Comparable<Object> {
 	 * @return Value of property m_iMatchTyp.
 	 */
 	public MatchType getMatchType() {
-		if ((m_mtMatchTyp == null) || (m_mtMatchTyp == MatchType.NONE)
-				|| m_mtMatchTyp == MatchType.CUP && (m_mtCupLevel == null || m_mtCupLevel == CupLevel.NONE)) {
+		if (m_mtMatchTyp == null || m_mtMatchTyp == MatchType.NONE) {
 			var m = OnlineWorker.inferMissingMatchType(this);
 			this.m_mtMatchTyp = m.getMatchType();
 			if (m_mtMatchTyp != MatchType.NONE) {


### PR DESCRIPTION
…chType of cup matches

1. changes proposed in this pull request:
 
   - fixes issue #1130 
   
   - if not fixing an existing issue, comments explaining the purpose of the PR should be provided)
 
 
2. changelog and release_notes ...

 - [ ] have been updated
 - [x] do not require update


3. [Optional] suggested person to review this PR @___
