### PR TITLE
Invoke close window handler when exiting app on macos.

### DIFF
--- a/src/main/java/core/HO.java
+++ b/src/main/java/core/HO.java
@@ -79,6 +79,7 @@ public class HO {
 		if (platform == OSUtils.OS.MAC) {
 			System.setProperty("apple.laf.useScreenMenuBar", "true");
 			System.setProperty("apple.awt.showGroupBox", "true");
+			System.setProperty("apple.eawt.quitStrategy", "CLOSE_ALL_WINDOWS");
 		}
 
 		System.setProperty("sun.awt.exception.handler", ExceptionHandler.class.getName());

--- a/src/main/resources/release_notes.md
+++ b/src/main/resources/release_notes.md
@@ -43,6 +43,7 @@
 ### Misc
 * fix finance bug concerning missing spectators' income in misc module (#1282)
 * fix last weeks profit/loss, temporary income sum and missing sponsors bonus (#1301)
+* fix CHPP token not being saved when exiting HO on macos (#1291)
 
 ## Translations
 - HO! is currently available in 36 languages thanks to the work of 57 translators: : _KOHb_, Adrian, akasolace, André Oliveira, Andreas, Ante, asteins, Baler0, Bartosz Fenski, beri84, Bogux, Boy van der Werf, brokenelevator, Bruno Nascimento, Cris, Csaba, DavidatorusF, Dinko, dzsoo, Fresty di Lot, Globe96, Gokmen, GreenHattrick, h3t3r0, Hakkarainen, imikacic, Juan Manuel, karelant. cd, Kimmo, LA-Dzigo, LEOSCHUMY, LeSchmuh, Lidegand, Manny, Massimo, Mauro Aranda, mondstern, Moorhuhninho, Motavali, murko, Philipp, QueenF, Raffael, RaV, Ricardo Salgueiro, Saleh, Sebas90, Sergejs Harkovs, sich, silvio, Stef Migchielsen, Sumame. esta, taimikko, TeamBMW, Volker, wsbrenk, Zigmas


### PR DESCRIPTION
This fixes #1291.  User preferences are only saved upon exiting HO, which calls
the `HOMainFrame#shutdown`.  On macos, when closing the app using Cmd+Q, it just
shuts down the JVM without performing the window closing handler.

The change ensures window closing events are triggered when using Cmd+Q.

1. changes proposed in this pull request:
 
   - fixes issue #1291 
   
2. changelog and release_notes ...

 - [x] have been updated
 - [ ] do not require update


3. [Optional] suggested person to review this PR @wsbrenk 
