### PR TITLE
#1542 SpielerTable.createObject load subexperience as double

### DIFF
--- a/src/main/java/core/db/SpielerTable.java
+++ b/src/main/java/core/db/SpielerTable.java
@@ -552,7 +552,7 @@ final class SpielerTable extends AbstractTable {
             player.setSubskill4PlayerSkill(PlayerSkill.SCORING,rs.getFloat("SubTorschuss"));
 			player.setSubskill4PlayerSkill(PlayerSkill.SET_PIECES,rs.getFloat("SubStandards"));
 
-			player.setSubExperience(rs.getFloat("SubExperience"));
+			player.setSubExperience(rs.getDouble("SubExperience"));
 			player.setNationalTeamId(rs.getInt("NationalTeamID"));
 
             player.setGelbeKarten(rs.getInt("GelbeKarten"));


### PR DESCRIPTION
1. changes proposed in this pull request:
 
   - fixes issue #1542 
   
   - if not fixing an existing issue, comments explaining the purpose of the PR should be provided)
 
 
2. changelog and release_notes ...

 - [ ] have been updated
 - [x] do not require update


3. [Optional] suggested person to review this PR @___
