### PR TITLE
#1644 2nd stop color in Group-Team.svg fixes exception - colors are s…

### DIFF
--- a/src/main/java/core/db/TeamsLogoTable.java
+++ b/src/main/java/core/db/TeamsLogoTable.java
@@ -1,22 +1,13 @@
 package core.db;
 
-import core.gui.HOMainFrame;
-import core.net.MyConnector;
 import core.util.HOLogger;
-import module.youth.YouthTraining;
-import module.youth.YouthTrainingType;
 import okhttp3.HttpUrl;
-import tool.updater.UpdateController;
 import tool.updater.UpdateHelper;
-
 import java.io.File;
 import java.nio.file.Path;
-import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Timestamp;
 import java.sql.Types;
-import java.util.ArrayList;
-import java.util.List;
 
 public class TeamsLogoTable extends AbstractTable {
     /**
@@ -63,7 +54,7 @@ public class TeamsLogoTable extends AbstractTable {
                 return null;
             } else {
                 logoURL = rs.getString("URL");
-                if (logoURL.equals("null")) {
+                if (logoURL == null || logoURL.equals("null")) {
                     HOLogger.instance().debug(this.getClass(), "team with no logo team ID=" + teamID);
                     return null;
                 }

--- a/src/main/resources/gui/bilder/smilies/Group-Team.svg
+++ b/src/main/resources/gui/bilder/smilies/Group-Team.svg
@@ -29,9 +29,11 @@
   <defs id="colors">
     <linearGradient id="fillColor" opacity="opacityVal">
       <stop offset="0" stop-color="#FF0000"/>
+      <stop offset="1" stop-color="#FF0000"/>
     </linearGradient>
     <linearGradient id="strokeColor" opacity="opacityVal">
       <stop offset="0" stop-color="#00FF00"/>
+      <stop offset="1" stop-color="#00FF00"/>
     </linearGradient>
   </defs>
   <sodipodi:namedview


### PR DESCRIPTION
…till broken

1. changes proposed in this pull request:
 
   - fixes issue #1644 (only exception is fixed, colors are still broken, when path contains umlaut characters)
   
   - if not fixing an existing issue, comments explaining the purpose of the PR should be provided)
 
 
2. changelog and release_notes ...

 - [ ] have been updated
 - [ ] do not require update


3. [Optional] suggested person to review this PR @___
