### PR TITLE
Do not return `true` when the application first starts

### DIFF
--- a/src/main/java/core/gui/model/PlayerAnalysisModel.java
+++ b/src/main/java/core/gui/model/PlayerAnalysisModel.java
@@ -39,7 +39,7 @@ public class PlayerAnalysisModel extends HOTableModel {
 	}
 	@Override
 	public boolean userCanDisableColumns(){
-		return true;
+		return !DBManager.instance().isFirstStart();
 	}
 
 	private void initialize() {

--- a/src/main/java/core/gui/model/PlayerOverviewModel.java
+++ b/src/main/java/core/gui/model/PlayerOverviewModel.java
@@ -1,5 +1,6 @@
 package core.gui.model;
 
+import core.db.DBManager;
 import core.gui.comp.table.HOTableModel;
 import core.gui.comp.table.UserColumn;
 import core.model.player.Player;
@@ -33,8 +34,8 @@ public final class PlayerOverviewModel extends HOTableModel {
 	}
 
 	@Override
-	public boolean userCanDisableColumns(){
-		return true;
+	public boolean userCanDisableColumns() {
+		return !DBManager.instance().isFirstStart();
 	}
 	
 	/**

--- a/src/main/resources/release_notes.md
+++ b/src/main/resources/release_notes.md
@@ -20,6 +20,7 @@ Please do not forget to back up data.
 ### Squad
 * add last match columns: rating at end of match, position and minutes (#1523)
 * add mother club and matches current team columns (#1401)
+* fix `ArrayIndexOutOfBoundsException` upon startup, as no column could be displayed (#1757)
 
 ### Team Analyser
 * team analyzer displays man marking tactic (#1741)


### PR DESCRIPTION
Fixes #1757, although this should probably be further improved by ensuring that if no column is selected, at least a default set of “core” columns still appear, like nationality, etc.

This was caused by the fact that there was no `UserColumn` to be displayed, as by default all columns are marked as `canDisplay` `false`.  This fix ensures that upon first start all columns are displayed, therefore the `UserColumnsTable` gets populated.  Subsequently the user can select the columns to show or hide.  Again we should either prevent the user from de-selecting everything, or not blow up when the user selects nothing (probably the better solution).


1. changes proposed in this pull request:
 
   - fixes issue #1757 
   
2. changelog and release_notes ...

 - [x] have been updated
 - [ ] do not require update


3. [Optional] suggested person to review this PR @wsbrenk 
