### PR TITLE
#1412 disable league promotion

### DIFF
--- a/src/main/java/module/series/promotion/LeaguePromotionHandler.java
+++ b/src/main/java/module/series/promotion/LeaguePromotionHandler.java
@@ -6,18 +6,13 @@ import com.google.gson.JsonObject;
 import core.db.DBManager;
 import core.gui.event.ChangeEventHandler;
 import core.model.HOVerwaltung;
-import core.model.UserParameter;
 import core.model.misc.Basics;
-import core.module.config.ModuleConfig;
 import core.util.HOLogger;
-
 import javax.swing.*;
 import javax.swing.event.*;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
-import java.util.stream.Collectors;
 
 /**
  * Main class for the League Promotion/Demotion prediction tool.
@@ -48,12 +43,14 @@ public class LeaguePromotionHandler extends ChangeEventHandler {
      * @return boolean – true if promotion manager can be used, false otherwise.
      */
     public boolean isActive(int seriesId) {
-        List<Integer> supportedLeagues = HttpDataSubmitter.instance().fetchSupportedLeagues();
-        int[] activeWeeks = ModuleConfig.instance().getIntArray("PromotionStatus_ActiveWeeks", new int[] { 14, 15 });
-        int week = HOVerwaltung.instance().getModel().getBasics().getSpieltag();
-        return UserParameter.instance().promotionManagerTest ||
-                (Arrays.stream(activeWeeks).boxed().collect(Collectors.toList()).contains(week) &&
-                        supportedLeagues.contains(seriesId));
+        // TODO: fix HT-Server. As long as it is not working this feature will be disabled
+        return false;
+//        List<Integer> supportedLeagues = HttpDataSubmitter.instance().fetchSupportedLeagues();
+//        int[] activeWeeks = ModuleConfig.instance().getIntArray("PromotionStatus_ActiveWeeks", new int[] { 14, 15 });
+//        int week = HOVerwaltung.instance().getModel().getBasics().getSpieltag();
+//        return UserParameter.instance().promotionManagerTest ||
+//                (Arrays.stream(activeWeeks).boxed().collect(Collectors.toList()).contains(week) &&
+//                        supportedLeagues.contains(seriesId));
     }
 
     public LeagueStatus getLeagueStatus() {
@@ -89,7 +86,7 @@ public class LeaguePromotionHandler extends ChangeEventHandler {
     }
 
     public void downloadLeagueData(int leagueId) {
-        final SwingWorker<Void, Void> worker = new SwingWorker<Void, Void>() {
+        final SwingWorker<Void, Void> worker = new SwingWorker<>() {
             @Override
             protected Void doInBackground() {
                 continueProcessing = (leagueStatus == LeagueStatus.NOT_AVAILABLE);
@@ -121,7 +118,7 @@ public class LeaguePromotionHandler extends ChangeEventHandler {
     }
 
     public void pollPromotionStatus() {
-        final SwingWorker<Void, Void> worker = new SwingWorker<Void, Void>() {
+        final SwingWorker<Void, Void> worker = new SwingWorker<>() {
             @Override
             protected Void doInBackground() {
                 HOLogger.instance().info(LeaguePromotionHandler.class, "Polling until status available");

--- a/src/main/resources/release_notes.md
+++ b/src/main/resources/release_notes.md
@@ -54,6 +54,7 @@
 
 ### League
 * fix order of last 5 matches - use the same as hattrick (#1793)
+* disable league promotion feature (#1412)
 
 ### Youth
 * duration format d hh:mm:ss of "can be promoted in" when less than one day is left (#1578)


### PR DESCRIPTION
1. changes proposed in this pull request:

disables the league promotion handler. Should be reset when ht server is working again.

2. `src/main/resources/release_notes.md` ...

 - [x] has been updated
 - [ ] does not require update


3. [Optional] suggested person to review this PR @___
