### PR TITLE
fixing reference to `second_team` in installing_ho.rst

### DIFF
--- a/docs/installing_ho.rst
+++ b/docs/installing_ho.rst
@@ -283,4 +283,4 @@ Add another team to HO
 *********************************
 
 It is possible to have multiple teams managed by HO! (c.f.
-:ref:``second_team``)
+:ref:`second_team`)


### PR DESCRIPTION
The reference to second_team had double back ticks instead of single

1. changes proposed in this pull request:

   - fixes issue #___
   - if not fixing an existing issue, comments explaining the purpose of the PR should be provided)


2. `src/main/resources/release_notes.md` ...

 - [ ] has been updated
 - [ ] does not require update


3. [Optional] suggested person to review this PR @___
