### PR TITLE
Add a Linux-friendly theme, called Gnome.

### DIFF
--- a/src/main/java/core/gui/theme/ThemeManager.java
+++ b/src/main/java/core/gui/theme/ThemeManager.java
@@ -8,6 +8,7 @@ import core.db.user.UserManager;
 import core.gui.HOMainFrame;
 import core.gui.theme.dark.DarculaDarkTheme;
 import core.gui.theme.dark.SolarizedDarkTheme;
+import core.gui.theme.gnome.GnomeTheme;
 import core.gui.theme.ho.HOClassicSchema;
 import core.gui.theme.light.SolarizedLightTheme;
 import core.gui.theme.nimbus.NimbusTheme;
@@ -34,6 +35,9 @@ import javax.imageio.ImageIO;
 import javax.swing.*;
 import javax.swing.text.*;
 
+/**
+ * Manages all the HO Themes.
+ */
 public final class ThemeManager {
 
 	/** Name of the default theme. */
@@ -45,7 +49,6 @@ public final class ThemeManager {
 	private final static Path playerAvatarPath = tempImgPath.resolve("playersAvatar");
 	private final static File playerAvatarDir = new File(String.valueOf(playerAvatarPath));
 	private final static Map<String, Theme> themes = new LinkedHashMap<>();
-
 	private final static ThemeManager MANAGER = new ThemeManager();
 
 	HOClassicSchema classicSchema = new HOClassicSchema();
@@ -60,12 +63,17 @@ public final class ThemeManager {
 	}
 
 	private void initialize() {
+
 		themes.put(NimbusTheme.THEME_NAME, new NimbusTheme());
 		themes.put(DarculaDarkTheme.THEME_NAME, new DarculaDarkTheme());
 // Comment out those themes for now as they are not ready yet.
 //		themes.put(HighContrastTheme.THEME_NAME, new HighContrastTheme());
 		themes.put(SolarizedDarkTheme.THEME_NAME, new SolarizedDarkTheme());
 		themes.put(SolarizedLightTheme.THEME_NAME, new SolarizedLightTheme());
+
+		if (OSUtils.isLinux()) {
+			themes.put(GnomeTheme.THEME_NAME, new GnomeTheme());
+		}
 
 		if (!teamLogoDir.exists()) {
 			try {
@@ -145,7 +153,7 @@ public final class ThemeManager {
 		return tmp;
 	}
 
-	private Icon getIconImpl(String key){
+	private Icon getIconImpl(String key) {
 		Object tmp = classicSchema.get(key);
 		if(tmp == null)
 			return null;
@@ -282,7 +290,7 @@ public final class ThemeManager {
 			avatarPath = playerAvatarPath.resolve(avatar.getPlayerID() + ".png").toString();
 			avatarImg = new File(avatarPath);
 
-			if (! avatarImg.exists()) {
+			if (!avatarImg.exists()) {
 				missingAvatars.add(avatar);
 			}
 		}
@@ -291,18 +299,16 @@ public final class ThemeManager {
 		int i=1;
 		int iMax = missingAvatars.size();
 
-		for (var avatar:missingAvatars){
+		for (var avatar:missingAvatars) {
 			HOLogger.instance().info(this.getClass(), "Donwloading player's avatar: %s/%s".formatted(i, iMax));
 			HOMainFrame.instance().setInformation("Donwloading player's avatar: %s/%s".formatted(i, iMax), progress);
-			try{
+			try {
 				avatar.generateAvatar(playerAvatarPath);
-				}
-			catch (IOException e) {
-					HOLogger.instance().error(ThemeManager.class, "Error processing Player Avatar for player: " + avatar.getPlayerID());
-				}
-				i ++;
+			} catch (IOException e) {
+				HOLogger.instance().error(ThemeManager.class, "Error processing Player Avatar for player: " + avatar.getPlayerID());
 			}
-
+			i++;
+		}
 	}
 
 	public Icon getPlayerAvatar(int playerID){
@@ -315,7 +321,7 @@ public final class ThemeManager {
 		String avatarPath = playerAvatarPath.resolve(playerID + ".png").toString();
 		File avatarImg = new File(avatarPath);
 
-		if (! avatarImg.exists()) {
+		if (!avatarImg.exists()) {
 			HOLogger.instance().log(this.getClass(), "avatar for player " + playerID + " not found locally. It will be downloaded");
 			return getScaledIcon(HOIconName.NO_CLUB_LOGO, width, height);
 		}

--- a/src/main/java/core/gui/theme/gnome/GnomeTheme.java
+++ b/src/main/java/core/gui/theme/gnome/GnomeTheme.java
@@ -1,0 +1,66 @@
+package core.gui.theme.gnome;
+
+import core.gui.comp.panel.ImagePanel;
+import core.gui.comp.panel.RasenPanel;
+import core.gui.theme.BaseTheme;
+import core.gui.theme.HOIconName;
+import core.gui.theme.ImageUtilities;
+import core.gui.theme.ThemeManager;
+import core.gui.theme.nimbus.NimbusTheme;
+import core.model.UserParameter;
+import core.util.HOLogger;
+import core.util.OSUtils;
+
+import javax.swing.*;
+import java.awt.*;
+import java.util.Arrays;
+import java.util.Optional;
+
+/**
+ * GNOME Theme for Linux machines.
+ */
+public class GnomeTheme extends BaseTheme {
+
+    public final static String THEME_NAME = "Gnome";
+
+    @Override
+    public String getName() {
+        return THEME_NAME;
+    }
+
+    @Override
+    public boolean loadTheme() {
+        return enableTheme(UserParameter.instance().fontSize);
+    }
+
+    public boolean enableTheme(int fontSize) {
+        // This is a Linux-only theme.
+        if (!OSUtils.isLinux()) {
+            return false;
+        }
+
+        try {
+
+            final Optional<UIManager.LookAndFeelInfo> lafInfoOpt = Arrays.stream(UIManager.getInstalledLookAndFeels())
+                    .filter(lookAndFeelInfo -> "GTK+".equals(lookAndFeelInfo.getName()))
+                    .findFirst();
+
+            if (lafInfoOpt.isPresent()) {
+                final UIManager.LookAndFeelInfo lafInfo = lafInfoOpt.get();
+
+                UIManager.setLookAndFeel(lafInfo.getClassName());
+                setFont(fontSize);
+
+                UIManager.put("Table.gridColor", Color.LIGHT_GRAY);
+
+                RasenPanel.background = ImageUtilities.toBufferedImage(ThemeManager.getIcon(HOIconName.GRASSPANEL_BACKGROUND));
+                ImagePanel.background = ImageUtilities.toBufferedImage(ThemeManager.getIcon(HOIconName.IMAGEPANEL_BACKGROUND));
+
+                return true;
+            }
+        } catch (Exception e) {
+            HOLogger.instance().log(NimbusTheme.class, e);
+        }
+        return false;
+    }
+}

--- a/src/main/java/core/gui/theme/nimbus/NimbusTheme.java
+++ b/src/main/java/core/gui/theme/nimbus/NimbusTheme.java
@@ -20,6 +20,7 @@ public class NimbusTheme extends BaseTheme {
 
 	public final static String THEME_NAME = "Nimbus";
 
+	@Override
 	public String getName() {
 		return THEME_NAME;
 	}
@@ -32,13 +33,14 @@ public class NimbusTheme extends BaseTheme {
 	public boolean enableTheme(int fontSize) {
 		try {
 			LookAndFeelInfo nimbus = null;
+
 			for (LookAndFeelInfo info : UIManager.getInstalledLookAndFeels()) {
-		        if ("Nimbus".equals(info.getName())) {
-		            nimbus = info;
-		            break;
-		        }
-		    }
-			
+				if ("Nimbus".equals(info.getName())) {
+					nimbus = info;
+					break;
+				}
+			}
+
 			if (nimbus != null) {
 				if (OSUtils.isMac()) {
 					UIManager.setLookAndFeel(UIManager.getSystemLookAndFeelClassName());
@@ -61,7 +63,7 @@ public class NimbusTheme extends BaseTheme {
 
 				setFont(fontSize);
 				UIDefaults uid = UIManager.getLookAndFeelDefaults();
-				
+
 				uid.put("Table.intercellSpacing", new DimensionUIResource(1, 1));
 				uid.put("Table.showGrid", Boolean.TRUE);
 				uid.put("Table.gridColor", new ColorUIResource(214, 217, 223));

--- a/src/main/resources/release_notes.md
+++ b/src/main/resources/release_notes.md
@@ -66,6 +66,7 @@
 
 ### Misc
 * fix display of wrong currency and character encoding when ht worldetails table wasn't initialized (#1622)
+* Add a Linux-friendly default theme, called “Gnome.”
 
 ## Translations
 


### PR DESCRIPTION
1. changes proposed in this pull request:
The default layout (Nimbus) does not look very good on Linux, in particular the colour of the panels, and the scrollbars.  This PR provides a very simple theme, based on the Gtk L&F to make HO a bit less out of place on Gnome env.

Before:

![Screenshot from 2023-04-29 14-08-27](https://user-images.githubusercontent.com/114285/235304237-5dbb038c-d045-43af-bb85-752ca6d618a0.png)

After:

![Screenshot from 2023-04-29 14-07-47](https://user-images.githubusercontent.com/114285/235304243-45e8a5e8-970d-4b51-ba10-39ddedf4f648.png)



2. `src/main/resources/release_notes.md` ...

 - [x] has been updated
 - [ ] does not require update


3. [Optional] suggested person to review this PR @wsbrenk 
