### PR TITLE
rebuild stable HO7

### DIFF
--- a/docs/lateststable.html
+++ b/docs/lateststable.html
@@ -1,2 +1,2 @@
-version=7.0.489.2
-released=22.04.2023
+version=7.0.494.2
+released=29.04.2023


### PR DESCRIPTION
1. changes proposed in this pull request:

 creating the release/7 branch destroyed the tag_stable download.
Rebuild should fix that.


2. `src/main/resources/release_notes.md` ...

 - [ ] has been updated
 - [ ] does not require update


3. [Optional] suggested person to review this PR @___
