### PR TITLE
Update install4j version to 10.0.6

### DIFF
--- a/.github/workflows/release-dev.yml
+++ b/.github/workflows/release-dev.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Validate Gradle wrapper
         uses: gradle/wrapper-validation-action@v1
       - name: Download and install install4j
-        run: wget https://download-gcdn.ej-technologies.com/install4j/install4j_linux-x64_9_0_7.deb && sudo dpkg -i install4j_linux-x64_9_0_7.deb
+        run: wget https://download-gcdn.ej-technologies.com/install4j/install4j_linux-x64_10_0_6.deb && sudo dpkg -i install4j_linux-x64_10_0_6.deb
       - name: Build with Gradle
         run: ./gradlew build makeAllmedias -x test
         env:

--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,7 @@ repositories {
 }
 
 dependencies {
-    implementation 'com.install4j:install4j-runtime:8.0.7'
+    implementation 'com.install4j:install4j-runtime:10.0.6'
     implementation 'com.github.scribejava:scribejava-core:8.3.3'
     implementation 'org.hsqldb:hsqldb:2.7.1'
     implementation 'com.google.code.gson:gson:2.10'

--- a/src/main/resources/release_notes.md
+++ b/src/main/resources/release_notes.md
@@ -31,6 +31,7 @@
 
 ### Misc
 * Add a Linux-friendly default theme, called “Gnome.”
+* Update Install4j to latest version (10.0.6) (#1849)
 
 ## Translations
 

--- a/utils/buildResources/HO.install4j
+++ b/utils/buildResources/HO.install4j
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<install4j version="9.0.7" transformSequenceNumber="9">
+<install4j version="10.0.6" transformSequenceNumber="10">
   <directoryPresets config="." />
   <application name="Hattrick Organizer" applicationId="7901-8968-2695-6971" mediaDir="${compiler:projectDir}/build/artefacts" mediaFilePattern="${compiler:sys.shortName}-${compiler:sys.version}${compiler:versionType}" shortName="HO" version="${compiler:HO_version}" allPathsRelative="true" convertDotsToUnderscores="false" macVolumeId="509e74c97593e805" javaMinVersion="14">
     <languages skipLanguageSelection="true">
@@ -37,7 +37,7 @@
     </variables>
     <jreBundles jdkProviderId="AdoptOpenJDK" release="17/jdk-17.0.3+7" />
   </application>
-  <files defaultFileMode="666" defaultDirMode="777" preserveSymlinks="false">
+  <files defaultFileMode="666" defaultDirMode="777">
     <mountPoints>
       <mountPoint id="58" />
     </mountPoints>
@@ -1118,7 +1118,7 @@ return true;</property>
     </styles>
   </installerGui>
   <mediaSets>
-    <windowsArchive name="Windows Archive" id="64" mediaFileName="${compiler:sys.shortName}-${compiler:sys.version}-portable-win${compiler:versionType}" installDir=".">
+    <windowsArchive name="Windows Archive" id="64" mediaFileName="${compiler:sys.shortName}-${compiler:sys.version}-portable-win${compiler:versionType}" installDir="." architecture="64">
       <excludedLaunchers>
         <launcher id="274" />
         <launcher id="497" />
@@ -1126,14 +1126,14 @@ return true;</property>
       </excludedLaunchers>
       <jreBundle jreBundleSource="none" />
     </windowsArchive>
-    <windowsArchive name="Windows Archive - JRE" id="481" mediaFileName="${compiler:sys.shortName}-${compiler:sys.version}-portable-win${compiler:versionType}-JRE" installDir=".">
+    <windowsArchive name="Windows Archive - JRE" id="481" mediaFileName="${compiler:sys.shortName}-${compiler:sys.version}-portable-win${compiler:versionType}-JRE" installDir="." architecture="64">
       <excludedLaunchers>
         <launcher id="274" />
         <launcher id="497" />
         <launcher id="606" />
       </excludedLaunchers>
     </windowsArchive>
-    <windows name="Windows" id="60" mediaFileName="HOSetup-${compiler:HO_version}${compiler:versionType}">
+    <windows name="Windows" id="60" mediaFileName="HOSetup-${compiler:HO_version}${compiler:versionType}" architecture="64">
       <excludedLaunchers>
         <launcher id="59" />
         <launcher id="274" />
@@ -1146,7 +1146,7 @@ return true;</property>
       </excludedBeans>
       <jreBundle usePack200="false" jreBundleSource="none" />
     </windows>
-    <windows name="Windows - JRE" id="485" mediaFileName="HOSetup-${compiler:HO_version}${compiler:versionType}-JRE">
+    <windows name="Windows - JRE" id="485" mediaFileName="HOSetup-${compiler:HO_version}${compiler:versionType}-JRE" architecture="64">
       <excludedLaunchers>
         <launcher id="59" />
         <launcher id="274" />
@@ -1249,7 +1249,7 @@ return true;</property>
         <bean refId="1222" />
       </excludedBeans>
     </unixInstaller>
-    <windows name="Windows (32bits)" id="1203" mediaFileName="HOSetup-32bits-${compiler:HO_version}${compiler:versionType}" jreBitType="32">
+    <windows name="Windows (32bits)" id="1203" mediaFileName="HOSetup-32bits-${compiler:HO_version}${compiler:versionType}" architecture="32">
       <excludedLaunchers>
         <launcher id="59" />
         <launcher id="274" />
@@ -1262,7 +1262,7 @@ return true;</property>
       </excludedBeans>
       <jreBundle usePack200="false" jreBundleSource="none" />
     </windows>
-    <windows name="Windows (32bits) - JRE" id="1206" mediaFileName="HOSetup-32bits-${compiler:HO_version}${compiler:versionType}-JRE" jreBitType="32">
+    <windows name="Windows (32bits) - JRE" id="1206" mediaFileName="HOSetup-32bits-${compiler:HO_version}${compiler:versionType}-JRE" architecture="32">
       <excludedLaunchers>
         <launcher id="59" />
         <launcher id="274" />
@@ -1275,7 +1275,7 @@ return true;</property>
       </excludedBeans>
       <jreBundle usePack200="false" />
     </windows>
-    <windowsArchive name="Windows (32bits) Archive" id="1208" mediaFileName="${compiler:sys.shortName}-${compiler:sys.version}-portable-win-32bits-${compiler:versionType}" installDir="." jreBitType="32">
+    <windowsArchive name="Windows (32bits) Archive" id="1208" mediaFileName="${compiler:sys.shortName}-${compiler:sys.version}-portable-win-32bits-${compiler:versionType}" installDir="." architecture="32">
       <excludedLaunchers>
         <launcher id="274" />
         <launcher id="497" />
@@ -1283,7 +1283,7 @@ return true;</property>
       </excludedLaunchers>
       <jreBundle jreBundleSource="none" />
     </windowsArchive>
-    <windowsArchive name="Windows (32bits) Archive - JRE" id="1211" mediaFileName="${compiler:sys.shortName}-${compiler:sys.version}-portable-win(32bits)${compiler:versionType}-JRE" installDir="." jreBitType="32">
+    <windowsArchive name="Windows (32bits) Archive - JRE" id="1211" mediaFileName="${compiler:sys.shortName}-${compiler:sys.version}-portable-win(32bits)${compiler:versionType}-JRE" installDir="." architecture="32">
       <excludedLaunchers>
         <launcher id="274" />
         <launcher id="497" />


### PR DESCRIPTION
This is an attempt at fixing issue #1849 by updating install4j to the latest version, as it is unclear at this point what is causing the install to hang on some MacOS machines.

1. changes proposed in this pull request:

  See above, see if this fixes #1849 


2. `src/main/resources/release_notes.md` ...

 - [x] has been updated
 - [ ] does not require update


3. [Optional] suggested person to review this PR @wsbrenk 
